### PR TITLE
fix: log PostgreSQL connection cleanup failures

### DIFF
--- a/src/dbeaver-client.ts
+++ b/src/dbeaver-client.ts
@@ -219,7 +219,16 @@ export class DBeaverClient {
       const rows: any[][] = (res.rows || []).map((r: any) => columns.map((c: string) => r[c]));
       return { columns, rows, rowCount: typeof res.rowCount === 'number' ? res.rowCount : rows.length, executionTime: 0 };
     } finally {
-      try { await client.end(); } catch {}
+      try {
+        await client.end();
+      } catch (closeError) {
+        // ALWAYS log connection cleanup failures - they indicate resource leaks
+        console.error('Failed to close PostgreSQL connection:', {
+          error: closeError instanceof Error ? closeError.message : String(closeError),
+          host,
+          database
+        });
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes a critical silent failure in PostgreSQL connection cleanup that can lead to resource leaks.

## Problem

The empty catch block on line 222 of `src/dbeaver-client.ts` silently swallows all connection cleanup errors:

```typescript
} finally {
  try { await client.end(); } catch {}  // ❌ Empty catch block
}
```

This hides critical errors including:
- Connection pool exhaustion
- Network timeout errors during disconnect
- Transaction rollback failures
- Socket errors (ECONNRESET, EPIPE)

Without visibility into these failures, connection leaks accumulate silently until the database refuses new connections. When this happens, users see "too many connections" errors with no prior warning or log trail.

## Solution

Log all connection cleanup failures with relevant context (host, database, error message):

```typescript
} finally {
  try {
    await client.end();
  } catch (closeError) {
    console.error('Failed to close PostgreSQL connection:', {
      error: closeError instanceof Error ? closeError.message : String(closeError),
      host,
      database
    });
  }
}
```

## Context

This issue was identified during a code review while adding SQL Server support (PR #1 in my fork). The SQL Server implementation includes this logging, and this PR brings the PostgreSQL implementation up to the same standard for consistent error handling across database drivers.

## Testing

- [x] TypeScript build passes with no errors
- [x] Change is isolated to error logging only - no functional changes to connection logic
- [x] Follows existing error handling patterns in the codebase

## Severity

**CRITICAL** - Resource leaks can cause complete database connectivity failure in production environments.