### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ A production-ready Model Context Protocol (MCP) server that seamlessly integrate
 [![Downloads](https://img.shields.io/npm/dm/dbeaver-mcp-server.svg)](https://www.npmjs.com/package/dbeaver-mcp-server)
 [![GitHub stars](https://img.shields.io/github/stars/srthkdev/dbeaver-mcp-server.svg)](https://github.com/srthkdev/dbeaver-mcp-server)
 
+<a href="https://glama.ai/mcp/servers/@srthkdev/dbeaver-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@srthkdev/dbeaver-mcp-server/badge" alt="DBeaver Server MCP server" />
+</a>
+
 ## 🚀 Key Features
 
 ### 🔗 Universal Database Connectivity
@@ -302,5 +306,3 @@ MIT License - see LICENSE file for details
 - The open source community for inspiration and feedback
 
 > **Note**: This project is not officially affiliated with DBeaver or Anthropic. It's designed for real-world production use with AI assistants.
-
-


### PR DESCRIPTION
This PR adds a badge for the [DBeaver MCP Server](https://glama.ai/mcp/servers/@srthkdev/dbeaver-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@srthkdev/dbeaver-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@srthkdev/dbeaver-mcp-server/badge" alt="DBeaver Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.