### PR TITLE
fix(postgres): read SSL config from nested DBeaver JSON properties

### DIFF
--- a/src/dbeaver-client.ts
+++ b/src/dbeaver-client.ts
@@ -340,10 +340,17 @@ export class DBeaverClient {
     const password = connection.properties?.password || process.env.PGPASSWORD;
 
     // SSL handling
+    // DBeaver's JSON config format stores driver properties under a nested `properties` key,
+    // and SSL handler config under `handlers.postgre_ssl`. Check all locations.
+    const nestedProps = (connection.properties?.['properties'] as unknown as Record<string, unknown>) || {};
+    const sslHandler = (connection.properties?.['handlers'] as unknown as Record<string, unknown> | undefined)?.['postgre_ssl'] as Record<string, unknown> | undefined;
     const sslModeRaw =
       connection.properties?.['ssl.mode'] ||
       connection.properties?.['sslmode'] ||
-      connection.properties?.['ssl'];
+      connection.properties?.['ssl'] ||
+      nestedProps['sslmode'] ||
+      nestedProps['ssl'] ||
+      (sslHandler?.enabled ? ((sslHandler?.properties as Record<string, unknown>)?.['sslMode'] || 'require') : undefined);
     const sslMode = String(sslModeRaw ?? '').toLowerCase();
     const sslRootCert =
       connection.properties?.['sslrootcert'] ||

--- a/src/pools/connection-pool.ts
+++ b/src/pools/connection-pool.ts
@@ -130,7 +130,16 @@ export class ConnectionPoolManager {
 
   private getPostgresSslConfig(connection: DBeaverConnection): object {
     const props = connection.properties || {};
-    const sslMode = props.sslmode || props.ssl;
+    // DBeaver's JSON config format stores driver properties under a nested `properties` key,
+    // and SSL handler config under `handlers.postgre_ssl`. Check all locations.
+    const nestedProps = (props.properties as unknown as Record<string, unknown>) || {};
+    const sslHandler = (props.handlers as unknown as Record<string, unknown> | undefined)?.['postgre_ssl'] as Record<string, unknown> | undefined;
+    const sslMode =
+      props.sslmode ||
+      props.ssl ||
+      nestedProps['sslmode'] ||
+      nestedProps['ssl'] ||
+      (sslHandler?.enabled ? ((sslHandler?.properties as Record<string, unknown>)?.['sslMode'] || 'require') : undefined);
 
     if (sslMode === 'disable' || sslMode === 'false') {
       return { ssl: false };


### PR DESCRIPTION
## Problem

When using DBeaver's modern JSON config format (v21+), PostgreSQL connections configured with SSL fail with:

```
no pg_hba.conf entry for host "...", user "...", database "...", no encryption
```

even though SSL is correctly configured in DBeaver.

## Root Cause

DBeaver's JSON config format stores driver-level properties under a **nested** `properties` key and the SSL handler config under `handlers.postgre_ssl`, rather than at the top level of the connection properties object:

```json
{
  "configuration": {
    "url": "jdbc:postgresql://host:5432/mydb",
    "properties": {
      "sslmode": "require",
      "ssl": "true"
    },
    "handlers": {
      "postgre_ssl": {
        "enabled": true,
        "properties": { "sslMode": "require" }
      }
    }
  }
}
```

Both `getPostgresSslConfig` (in `connection-pool.ts`) and `executePostgreSQLQuery` (in `dbeaver-client.ts`) only read from the **top-level** `properties.sslmode` / `properties.ssl`, which are always `undefined` in this format. As a result, SSL mode falls back to the default or is treated as disabled, and the connection is sent without encryption — causing servers that require SSL (e.g. AWS RDS with `hostssl` in `pg_hba.conf`) to reject it.

## Fix

Both SSL-reading locations now also check:
- `properties.properties.sslmode` / `properties.properties.ssl` — nested driver props
- `properties.handlers.postgre_ssl.enabled` + `properties.handlers.postgre_ssl.properties.sslMode` — DBeaver's SSL handler block

## Testing

Verified against an AWS RDS PostgreSQL 15 instance configured with `hostssl` in `pg_hba.conf`. Before this fix, `test_connection` returned "no encryption" error. After the fix, the connection succeeds with SSL.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)