### PR TITLE
fix: DBeaver 25+ compat, add native ClickHouse HTTP driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **DBeaver 25+ compatibility**: query execution for drivers without a native branch (Oracle, ClickHouse pre-patch, etc.) silently timed out because the CLI fallback passed `-o`/`-of` flags that DBeaver 25 removed. DBeaver would ignore the flags, open the UI, and never exit. The CLI query fallback has been removed in favor of clear errors.
+- **`export_data` no longer depends on the CLI**: routed through the existing native drivers; CSV/JSON is produced in-process, fixing the same hang.
+
+### Added
+- **ClickHouse native driver**: query execution via the ClickHouse HTTP interface (`default_format=JSON`). TLS is selected automatically when `ssl=true` is set on the DBeaver connection or when the port is 443/8443. Auth uses `X-ClickHouse-User` / `X-ClickHouse-Key` headers.
+- **Clear error for unsupported drivers**: `executeQuery` now fails fast with a message listing the natively supported drivers instead of hanging for the full timeout.
+
+### Removed
+- Dead CLI plumbing: `executeViaCli`, `executeCli`, `isCliAvailable`, `parseCSVOutput`, `cleanupFiles`, the `csv-parser` usage in `workspace-client.ts`, and the unused `executablePath` field. The `_executablePath` constructor parameter is preserved (ignored) for backward compatibility.
+
 ## [2.0.1] - 2026-04-20
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ Add to Cursor Settings > MCP Servers:
 | `OMNISQL_POOL_MAX` | Maximum connections per pool | `10` |
 | `OMNISQL_POOL_IDLE_TIMEOUT` | Idle connection timeout (ms) | `30000` |
 | `OMNISQL_POOL_ACQUIRE_TIMEOUT` | Connection acquire timeout (ms) | `10000` |
+| `OMNISQL_OUTPUT_DIR` | Allow-root for `export_data` `outputPath` writes | `os.tmpdir()` |
+| `OMNISQL_ALLOW_ANY_OUTPUT_PATH` | Disable the allow-root check for `outputPath` | `false` |
 
 ### Read-Only Mode
 
@@ -164,7 +166,7 @@ Restrict which workspace connections are visible. Accepts connection IDs or disp
 ### Data Operations
 - `execute_query` - Run read-only queries (SELECT, EXPLAIN, SHOW, DESCRIBE only)
 - `write_query` - Run INSERT/UPDATE/DELETE
-- `export_data` - Export to CSV/JSON
+- `export_data` - Export to CSV, JSON, or JSONL. Set `outputPath` to dump to disk and receive a small summary (filePath, rowCount, byteSize, columns, previewRows) instead of the full payload — avoids bloating the LLM context for large result sets.
 
 ### Schema Management
 - `list_tables` - List tables and views

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,6 +71,8 @@ class OmniSQLMCPServer {
   private disabledTools: string[];
   private allowedConnections: Set<string> | null; // null = allow all
   private staleCleanupInterval: ReturnType<typeof setInterval> | null = null;
+  private outputDir: string;
+  private allowAnyOutputPath: boolean;
 
   constructor() {
     this.debug = process.env.OMNISQL_DEBUG === 'true';
@@ -87,6 +89,9 @@ class OmniSQLMCPServer {
       .map((c) => c.trim())
       .filter(Boolean);
     this.allowedConnections = allowedList.length > 0 ? new Set(allowedList) : null;
+
+    this.outputDir = path.resolve(process.env.OMNISQL_OUTPUT_DIR || os.tmpdir());
+    this.allowAnyOutputPath = process.env.OMNISQL_ALLOW_ANY_OUTPUT_PATH === 'true';
 
     this.insightsFile = path.join(os.tmpdir(), 'omnisql-mcp-insights.json');
 
@@ -170,6 +175,31 @@ class OmniSQLMCPServer {
     } catch (error) {
       this.log(`Failed to save insights: ${error}`, 'error');
     }
+  }
+
+  private resolveOutputPath(input: string): string {
+    if (this.allowAnyOutputPath) {
+      return path.resolve(input);
+    }
+    const root = this.outputDir;
+    const resolved = path.isAbsolute(input) ? path.resolve(input) : path.resolve(root, input);
+    const parent = path.dirname(resolved);
+    let realParent: string;
+    try {
+      realParent = fs.realpathSync(parent);
+    } catch {
+      realParent = parent;
+    }
+    const realResolved = path.join(realParent, path.basename(resolved));
+    const rel = path.relative(root, realResolved);
+    if (rel === '' || rel.startsWith('..') || path.isAbsolute(rel)) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        `outputPath must be inside OMNISQL_OUTPUT_DIR (${root}). Got: ${input}. ` +
+          `Set OMNISQL_ALLOW_ANY_OUTPUT_PATH=true to disable this check.`
+      );
+    }
+    return realResolved;
   }
 
   /**
@@ -469,7 +499,8 @@ class OmniSQLMCPServer {
         },
         {
           name: 'export_data',
-          description: 'Export query results to various formats (CSV, JSON, etc.)',
+          description:
+            'Export query results to CSV, JSON, or JSONL. When outputPath is set, writes to disk and returns a small summary (filePath, rowCount, byteSize, columns, previewRows) instead of the full payload — useful for large dumps that would otherwise bloat the LLM context.',
           inputSchema: {
             type: 'object',
             properties: {
@@ -483,8 +514,8 @@ class OmniSQLMCPServer {
               },
               format: {
                 type: 'string',
-                enum: ['csv', 'json'],
-                description: 'Export format (csv or json)',
+                enum: ['csv', 'json', 'jsonl'],
+                description: 'Export format (csv, json, or jsonl)',
                 default: 'csv',
               },
               includeHeaders: {
@@ -496,6 +527,11 @@ class OmniSQLMCPServer {
                 type: 'number',
                 description: 'Maximum number of rows to export',
                 default: 10000,
+              },
+              outputPath: {
+                type: 'string',
+                description:
+                  'Optional file path to write the export to. Relative paths resolve against OMNISQL_OUTPUT_DIR; absolute paths must live inside it unless OMNISQL_ALLOW_ANY_OUTPUT_PATH=true. When set, the response is a summary (filePath, rowCount, byteSize, columns, previewRows) instead of the full data.',
               },
             },
             required: ['connectionId', 'query'],
@@ -832,6 +868,7 @@ class OmniSQLMCPServer {
                 format?: string;
                 includeHeaders?: boolean;
                 maxRows?: number;
+                outputPath?: string;
               }
             );
 
@@ -1275,11 +1312,11 @@ class OmniSQLMCPServer {
     format?: string;
     includeHeaders?: boolean;
     maxRows?: number;
+    outputPath?: string;
   }) {
     const connectionId = sanitizeConnectionId(args.connectionId);
     const query = args.query.trim();
 
-    // Validate query - only SELECT queries for export
     if (!query.toLowerCase().trimStart().startsWith('select')) {
       throw new McpError(ErrorCode.InvalidParams, 'Only SELECT queries are allowed for export');
     }
@@ -1291,49 +1328,72 @@ class OmniSQLMCPServer {
 
     const requestedRows = args.maxRows || DEFAULT_EXPORT_ROWS;
     const maxRows = Math.min(Math.max(1, requestedRows), MAX_EXPORT_ROWS);
-    const format = args.format || 'csv';
+    const format = (args.format || 'csv') as 'csv' | 'json' | 'jsonl';
 
-    // Add LIMIT clause if not present
+    if (!['csv', 'json', 'jsonl'].includes(format)) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        `Unsupported export format: ${format}. Use 'csv', 'json', or 'jsonl'`
+      );
+    }
+
     let finalQuery = query;
     if (!query.toLowerCase().includes('limit')) {
       finalQuery = `${query} LIMIT ${maxRows}`;
     }
 
+    if (args.outputPath) {
+      const resolvedPath = this.resolveOutputPath(args.outputPath);
+      const { filePath, result } = await this.workspaceClient.exportData(connection, finalQuery, {
+        format,
+        outputPath: resolvedPath,
+      });
+      const byteSize = fs.statSync(filePath).size;
+      const summary = {
+        filePath,
+        format,
+        rowCount: result.rowCount,
+        byteSize,
+        columns: result.columns,
+        previewRows: result.rows.slice(0, 20),
+        truncated: result.rows.length >= maxRows,
+      };
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(summary, null, 2) }],
+      };
+    }
+
     const result = await this.workspaceClient.executeQuery(connection, finalQuery);
 
     if (format === 'csv') {
-      const csvData = convertToCSV(result.columns, result.rows);
       return {
-        content: [
-          {
-            type: 'text' as const,
-            text: csvData,
-          },
-        ],
+        content: [{ type: 'text' as const, text: convertToCSV(result.columns, result.rows) }],
       };
-    } else if (format === 'json') {
-      const jsonData = result.rows.map((row) => {
-        const obj: any = {};
-        result.columns.forEach((col, idx) => {
-          obj[col] = row[idx];
-        });
-        return obj;
-      });
-
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify(jsonData, null, 2),
-          },
-        ],
-      };
-    } else {
-      throw new McpError(
-        ErrorCode.InvalidParams,
-        `Unsupported export format: ${format}. Use 'csv' or 'json'`
-      );
     }
+
+    if (format === 'jsonl') {
+      const lines = result.rows
+        .map((row) => {
+          const obj: any = {};
+          result.columns.forEach((col, idx) => {
+            obj[col] = row[idx];
+          });
+          return JSON.stringify(obj);
+        })
+        .join('\n');
+      return { content: [{ type: 'text' as const, text: lines }] };
+    }
+
+    const jsonData = result.rows.map((row) => {
+      const obj: any = {};
+      result.columns.forEach((col, idx) => {
+        obj[col] = row[idx];
+      });
+      return obj;
+    });
+    return {
+      content: [{ type: 'text' as const, text: JSON.stringify(jsonData, null, 2) }],
+    };
   }
 
   private async handleTestConnection(args: { connectionId: string }) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,11 +57,22 @@ export interface ConstraintInfo {
 }
 
 export interface ExportOptions {
-  format: 'csv' | 'json' | 'xml' | 'excel' | 'sql';
-  includeHeaders: boolean;
+  format?: 'csv' | 'json' | 'jsonl';
+  includeHeaders?: boolean;
   delimiter?: string;
   encoding?: string;
   maxRows?: number;
+  outputPath?: string;
+}
+
+export interface ExportResult {
+  filePath: string;
+  format: 'csv' | 'json' | 'jsonl';
+  rowCount: number;
+  byteSize: number;
+  columns: string[];
+  previewRows: any[][];
+  truncated: boolean;
 }
 
 export interface WorkspaceConfig {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -214,6 +214,8 @@ export function getTestQuery(driver: string): string {
     return 'SELECT version();';
   } else if (driverLower.includes('mysql')) {
     return 'SELECT version();';
+  } else if (driverLower.includes('clickhouse')) {
+    return 'SELECT version();';
   } else if (driverLower.includes('oracle')) {
     return 'SELECT * FROM dual;';
   } else if (driverLower.includes('sqlite')) {

--- a/src/workspace-client.ts
+++ b/src/workspace-client.ts
@@ -3,7 +3,6 @@ import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
-import csv from 'csv-parser';
 import { Client } from 'pg';
 import sql from 'mssql';
 import mysql from 'mysql2/promise';
@@ -16,26 +15,26 @@ import {
   DatabaseStats,
 } from './types.js';
 import {
-  findCliExecutable,
   getTestQuery,
   parseVersionFromResult,
   buildSchemaQuery,
   buildListTablesQuery,
+  convertToCSV,
 } from './utils.js';
 
 export class WorkspaceClient {
-  private executablePath: string;
   private timeout: number;
   private debug: boolean;
   private workspacePath?: string;
 
   constructor(
-    executablePath?: string,
+    // Retained for backward compatibility; no longer used since the CLI fallback
+    // was removed (DBeaver 25+ dropped the -o/-of flags this server depended on).
+    _executablePath?: string,
     timeout: number = 30000,
     debug: boolean = false,
     workspacePath?: string
   ) {
-    this.executablePath = executablePath || findCliExecutable();
     this.timeout = timeout;
     this.debug = debug;
     this.workspacePath = workspacePath;
@@ -112,44 +111,40 @@ export class WorkspaceClient {
     query: string,
     options: ExportOptions
   ): Promise<string> {
+    const format = options.format || 'csv';
+    const supportedFormats: ExportOptions['format'][] = ['csv', 'json'];
+    if (!supportedFormats.includes(format)) {
+      throw new Error(
+        `Unsupported export format: ${format}. Supported formats: ${supportedFormats.join(', ')}.`
+      );
+    }
+
     const tempDir = os.tmpdir();
     const exportId = `export_${Date.now()}_${crypto.randomBytes(6).toString('hex')}`;
-    const sqlFile = path.join(tempDir, `${exportId}.sql`);
-    const outputFile = path.join(tempDir, `${exportId}_output.${options.format || 'csv'}`);
+    const outputFile = path.join(tempDir, `${exportId}_output.${format}`);
 
     try {
-      // Write query to temporary file
-      fs.writeFileSync(sqlFile, query, 'utf-8');
+      const result = await this.executeWithNativeTool(connection, query);
 
-      // Build CLI command arguments
-      const args = [
-        '-nosplash',
-        '-reuseWorkspace',
-        ...(this.workspacePath ? ['-data', this.workspacePath] : []),
-        '-con',
-        connection.id,
-        '-f',
-        sqlFile,
-        '-o',
-        outputFile,
-        '-of',
-        options.format || 'csv',
-        '-quit',
-      ];
-
-      await this.executeCli(args);
-
-      // Optionally, you could check if the file exists and return the path
-      if (!fs.existsSync(outputFile)) {
-        throw new Error('Export failed: output file not found');
+      let content: string;
+      if (format === 'csv') {
+        content = convertToCSV(result.columns, result.rows);
+      } else {
+        // json
+        const objects = result.rows.map((row) => {
+          const obj: Record<string, unknown> = {};
+          result.columns.forEach((col, idx) => {
+            obj[col] = row[idx];
+          });
+          return obj;
+        });
+        content = JSON.stringify(objects, null, 2);
       }
 
+      fs.writeFileSync(outputFile, content, 'utf-8');
       return outputFile;
     } catch (error) {
-      throw new Error(`Export failed: ${error}`);
-    } finally {
-      // Cleanup the SQL file, but keep the output file for the user
-      this.cleanupFiles([sqlFile]);
+      throw new Error(`Export failed: ${error instanceof Error ? error.message : String(error)}`);
     }
   }
 
@@ -192,86 +187,19 @@ export class WorkspaceClient {
       return this.executeSQLServerQuery(connection, query);
     } else if (driver.includes('mysql') || driver.includes('mariadb')) {
       return this.executeMySQLQuery(connection, query);
+    } else if (driver.includes('clickhouse')) {
+      return this.executeClickHouseQuery(connection, query);
     } else {
-      // Unsupported driver – try the CLI as a best-effort fallback, but
-      // wrap with a clear error message listing the natively supported drivers.
-      try {
-        return await this.executeViaCli(connection, query);
-      } catch (cliError) {
-        const driverName = connection.driver;
-        const nativeDrivers =
-          'PostgreSQL (+ CockroachDB, TimescaleDB, Redshift, YugabyteDB, Supabase, Neon, Citus, AlloyDB), MySQL/MariaDB, SQL Server (MSSQL), SQLite';
-        const cliMsg = cliError instanceof Error ? cliError.message : String(cliError);
-        throw new Error(
-          `Database driver "${driverName}" is not natively supported. ` +
-            `Natively supported drivers: ${nativeDrivers}. ` +
-            `CLI fallback also failed: ${cliMsg}. ` +
-            `To use "${driverName}", consider connecting through a supported driver ` +
-            `(e.g. via an ODBC/JDBC bridge) or ensure a compatible DB client CLI is installed and ` +
-            `the connection is configured in your workspace.`
-        );
-      }
-    }
-  }
-
-  private async executeViaCli(connection: DatabaseConnection, query: string): Promise<QueryResult> {
-    // Verify the CLI executable exists before attempting
-    if (!this.isCliAvailable()) {
+      const nativeDrivers =
+        'PostgreSQL (+ CockroachDB, TimescaleDB, Redshift, YugabyteDB, Supabase, Neon, Citus, AlloyDB), ' +
+        'MySQL/MariaDB, SQL Server (MSSQL), SQLite, ClickHouse';
       throw new Error(
-        'DB client CLI executable not found. Install a compatible CLI or set OMNISQL_CLI_PATH environment variable.'
+        `Database driver "${connection.driver}" is not supported. ` +
+          `Natively supported drivers: ${nativeDrivers}. ` +
+          `DBeaver 25+ removed the \`-o\`/\`-of\` CLI flags that older versions of this server relied on, ` +
+          `so the CLI fallback has been removed. To add support for a new driver, contribute a native ` +
+          `implementation that speaks the database's wire/HTTP protocol directly.`
       );
-    }
-
-    const tempDir = os.tmpdir();
-    const exportId = `query_${Date.now()}_${crypto.randomBytes(6).toString('hex')}`;
-    const sqlFile = path.join(tempDir, `${exportId}.sql`);
-    const outputFile = path.join(tempDir, `${exportId}_output.csv`);
-
-    try {
-      fs.writeFileSync(sqlFile, query, 'utf-8');
-
-      // Build connection spec - try name first, then ID
-      const conSpec = `name=${connection.name}`;
-
-      const args = [
-        '-nosplash',
-        '-reuseWorkspace',
-        ...(this.workspacePath ? ['-data', this.workspacePath] : []),
-        '-con',
-        conSpec,
-        '-f',
-        sqlFile,
-        '-o',
-        outputFile,
-        '-of',
-        'csv',
-        '-quit',
-      ];
-
-      await this.executeCli(args);
-
-      if (!fs.existsSync(outputFile)) {
-        // Some non-SELECT statements may not produce a resultset/export file.
-        return { columns: [], rows: [], rowCount: 0, executionTime: 0 };
-      }
-
-      return await this.parseCSVOutput(outputFile);
-    } finally {
-      this.cleanupFiles([sqlFile, outputFile]);
-    }
-  }
-
-  private isCliAvailable(): boolean {
-    try {
-      // Check if the executable path exists (skip for bare command names that rely on PATH)
-      if (this.executablePath.includes('/') || this.executablePath.includes('\\')) {
-        return fs.existsSync(this.executablePath);
-      }
-      // For bare command names on PATH, we cannot easily verify presence here,
-      // so assume it might be available and let executeCli surface any error
-      return true;
-    } catch {
-      return false;
     }
   }
 
@@ -618,82 +546,96 @@ export class WorkspaceClient {
     }
   }
 
-  private async executeCli(args: string[]): Promise<void> {
-    return new Promise((resolve, reject) => {
-      const proc = spawn(this.executablePath, args, { stdio: this.debug ? 'inherit' : 'ignore' });
+  private async executeClickHouseQuery(
+    connection: DatabaseConnection,
+    query: string
+  ): Promise<QueryResult> {
+    const host = connection.host || connection.properties?.host || 'localhost';
+    const portRaw = connection.port ?? connection.properties?.port;
+    const port = portRaw ? parseInt(String(portRaw)) : 8123;
+    const user = connection.user || connection.properties?.user || 'default';
+    const password = connection.properties?.password || '';
+    const database = connection.database || connection.properties?.database || 'default';
 
-      // Set up timeout
-      const timeoutId = setTimeout(() => {
-        proc.kill('SIGTERM');
-        reject(new Error(`CLI execution timed out after ${this.timeout}ms`));
-      }, this.timeout);
+    // ClickHouse SSL config may live at properties.ssl, nested properties.properties.ssl,
+    // the legacy `ssl.mode`, or the `clickhouse-ssl` handler block.
+    const nestedProps =
+      (connection.properties?.['properties'] as unknown as Record<string, unknown>) || {};
+    const sslHandler = (
+      connection.properties?.['handlers'] as unknown as Record<string, unknown> | undefined
+    )?.['clickhouse-ssl'] as Record<string, unknown> | undefined;
+    const sslRaw =
+      connection.properties?.['ssl'] ||
+      connection.properties?.['ssl.mode'] ||
+      nestedProps['ssl'] ||
+      nestedProps['ssl.mode'] ||
+      (sslHandler?.enabled ? 'true' : undefined);
+    const sslFlag = String(sslRaw ?? '').toLowerCase();
+    const explicitSsl = ['true', '1', 'yes', 'require', 'enabled', 'on'].includes(sslFlag);
+    const explicitNoSsl = ['false', '0', 'no', 'disable', 'off', 'none'].includes(sslFlag);
+    // Default to HTTPS when the JDBC port looks like a TLS port and SSL isn't explicitly disabled.
+    const useHttps = explicitSsl || (!explicitNoSsl && (port === 443 || port === 8443));
+    const proto = useHttps ? 'https' : 'http';
 
-      proc.on('error', (error) => {
-        clearTimeout(timeoutId);
-        reject(error);
+    const url =
+      `${proto}://${host}:${port}/?default_format=JSON` +
+      `&database=${encodeURIComponent(database)}`;
+    const headers: Record<string, string> = {
+      'Content-Type': 'text/plain; charset=UTF-8',
+    };
+    if (user) headers['X-ClickHouse-User'] = user;
+    if (password) headers['X-ClickHouse-Key'] = password;
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), this.timeout);
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        method: 'POST',
+        headers,
+        body: query,
+        signal: controller.signal,
       });
-
-      proc.on('exit', (code) => {
-        clearTimeout(timeoutId);
-        if (code === 0) {
-          resolve();
-        } else {
-          reject(new Error(`CLI process exited with code ${code}`));
-        }
-      });
-    });
-  }
-
-  private cleanupFiles(files: string[]): void {
-    for (const file of files) {
-      try {
-        if (fs.existsSync(file)) {
-          fs.unlinkSync(file);
-        }
-      } catch {
-        // Ignore errors
+    } catch (err: any) {
+      if (err?.name === 'AbortError') {
+        throw new Error(`ClickHouse request timed out after ${this.timeout}ms`);
       }
+      throw new Error(
+        `ClickHouse request failed: ${err instanceof Error ? err.message : String(err)}`
+      );
+    } finally {
+      clearTimeout(timeoutId);
     }
-  }
 
-  private async parseCSVOutput(filePath: string): Promise<QueryResult> {
-    return new Promise((resolve, reject) => {
-      const rows: any[] = [];
-      let columns: string[] = [];
-      let rowCount = 0;
+    const bodyText = await response.text();
+    if (!response.ok) {
+      // ClickHouse error bodies are plain text; trim and truncate to keep the message readable.
+      const snippet = bodyText.trim().split('\n').slice(0, 4).join(' ').slice(0, 800);
+      throw new Error(`ClickHouse HTTP ${response.status}: ${snippet}`);
+    }
 
-      // Check if file exists first
-      if (!fs.existsSync(filePath)) {
-        reject(new Error(`Output file not found: ${filePath}`));
-        return;
-      }
+    const trimmed = bodyText.trim();
+    if (!trimmed) {
+      // DDL/INSERT statements return an empty body.
+      return { columns: [], rows: [], rowCount: 0, executionTime: 0 };
+    }
 
-      try {
-        const stats = fs.statSync(filePath);
-        if (stats.size === 0) {
-          resolve({ columns: [], rows: [], rowCount: 0, executionTime: 0 });
-          return;
-        }
-      } catch {
-        // If stat fails, continue and let the stream handle errors
-      }
+    let parsed: any;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      // Non-JSON response (e.g. a statement ClickHouse decided to return as TSV) — treat as empty resultset.
+      return { columns: [], rows: [], rowCount: 0, executionTime: 0 };
+    }
 
-      fs.createReadStream(filePath)
-        .pipe(csv())
-        .on('headers', (headers) => {
-          columns = headers;
-        })
-        .on('data', (data) => {
-          rows.push(Object.values(data));
-          rowCount++;
-        })
-        .on('end', () => {
-          resolve({ columns, rows, rowCount, executionTime: 0 });
-        })
-        .on('error', (error) => {
-          reject(new Error(`CSV parsing failed: ${error.message}`));
-        });
-    });
+    const meta: any[] = Array.isArray(parsed.meta) ? parsed.meta : [];
+    const data: any[] = Array.isArray(parsed.data) ? parsed.data : [];
+    const columns: string[] = meta.map((m) => String(m.name));
+    const rows: any[][] = data.map((row: Record<string, unknown>) =>
+      columns.map((c) => row[c] as unknown)
+    );
+    const rowCount = typeof parsed.rows === 'number' ? parsed.rows : rows.length;
+    return { columns, rows, rowCount, executionTime: 0 };
   }
 
   private getTestQuery(driver: string): string {

--- a/src/workspace-client.ts
+++ b/src/workspace-client.ts
@@ -110,18 +110,24 @@ export class WorkspaceClient {
     connection: DatabaseConnection,
     query: string,
     options: ExportOptions
-  ): Promise<string> {
+  ): Promise<{ filePath: string; format: 'csv' | 'json' | 'jsonl'; result: QueryResult }> {
     const format = options.format || 'csv';
-    const supportedFormats: ExportOptions['format'][] = ['csv', 'json'];
+    const supportedFormats: NonNullable<ExportOptions['format']>[] = ['csv', 'json', 'jsonl'];
     if (!supportedFormats.includes(format)) {
       throw new Error(
         `Unsupported export format: ${format}. Supported formats: ${supportedFormats.join(', ')}.`
       );
     }
 
-    const tempDir = os.tmpdir();
-    const exportId = `export_${Date.now()}_${crypto.randomBytes(6).toString('hex')}`;
-    const outputFile = path.join(tempDir, `${exportId}_output.${format}`);
+    let outputFile: string;
+    if (options.outputPath) {
+      outputFile = options.outputPath;
+      fs.mkdirSync(path.dirname(outputFile), { recursive: true });
+    } else {
+      const tempDir = os.tmpdir();
+      const exportId = `export_${Date.now()}_${crypto.randomBytes(6).toString('hex')}`;
+      outputFile = path.join(tempDir, `${exportId}_output.${format}`);
+    }
 
     try {
       const result = await this.executeWithNativeTool(connection, query);
@@ -129,8 +135,18 @@ export class WorkspaceClient {
       let content: string;
       if (format === 'csv') {
         content = convertToCSV(result.columns, result.rows);
+      } else if (format === 'jsonl') {
+        content =
+          result.rows
+            .map((row) => {
+              const obj: Record<string, unknown> = {};
+              result.columns.forEach((col, idx) => {
+                obj[col] = row[idx];
+              });
+              return JSON.stringify(obj);
+            })
+            .join('\n') + (result.rows.length > 0 ? '\n' : '');
       } else {
-        // json
         const objects = result.rows.map((row) => {
           const obj: Record<string, unknown> = {};
           result.columns.forEach((col, idx) => {
@@ -142,7 +158,7 @@ export class WorkspaceClient {
       }
 
       fs.writeFileSync(outputFile, content, 'utf-8');
-      return outputFile;
+      return { filePath: outputFile, format, result };
     } catch (error) {
       throw new Error(`Export failed: ${error instanceof Error ? error.message : String(error)}`);
     }

--- a/tests/workspace-client.test.ts
+++ b/tests/workspace-client.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { WorkspaceClient } from '../src/workspace-client.js';
+import type { DatabaseConnection } from '../src/types.js';
+
+const ORIGINAL_FETCH = globalThis.fetch;
+
+function clickhouseConn(overrides: Partial<DatabaseConnection> = {}): DatabaseConnection {
+  return {
+    id: 'clickhouse-1',
+    name: 'test-ch',
+    driver: 'com_clickhouse',
+    url: 'jdbc:clickhouse://ch.example:443',
+    host: 'ch.example',
+    port: 443,
+    database: 'default',
+    user: 'nemo',
+    properties: { password: 'secret', ssl: 'true', sslmode: 'none' },
+    ...overrides,
+  };
+}
+
+describe('WorkspaceClient.executeQuery — driver routing', () => {
+  let client: WorkspaceClient;
+
+  beforeEach(() => {
+    client = new WorkspaceClient(undefined, 5000, false, '/tmp/fake-ws');
+  });
+
+  afterEach(() => {
+    globalThis.fetch = ORIGINAL_FETCH;
+    vi.restoreAllMocks();
+  });
+
+  it('routes ClickHouse driver to HTTPS endpoint with auth headers and JSON format', async () => {
+    const capturedUrls: string[] = [];
+    const capturedInit: RequestInit[] = [];
+    globalThis.fetch = vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
+      capturedUrls.push(String(url));
+      capturedInit.push(init ?? {});
+      return new Response(
+        JSON.stringify({
+          meta: [
+            { name: 'one', type: 'UInt8' },
+            { name: 'label', type: 'String' },
+          ],
+          data: [{ one: 1, label: 'hello' }],
+          rows: 1,
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      );
+    }) as typeof fetch;
+
+    const result = await client.executeQuery(clickhouseConn(), "SELECT 1 AS one, 'hello' AS label");
+
+    expect(result.columns).toEqual(['one', 'label']);
+    expect(result.rows).toEqual([[1, 'hello']]);
+    expect(result.rowCount).toBe(1);
+
+    expect(capturedUrls[0]).toMatch(/^https:\/\/ch\.example:443\//);
+    expect(capturedUrls[0]).toContain('default_format=JSON');
+    expect(capturedUrls[0]).toContain('database=default');
+
+    const headers = (capturedInit[0]?.headers ?? {}) as Record<string, string>;
+    expect(headers['X-ClickHouse-User']).toBe('nemo');
+    expect(headers['X-ClickHouse-Key']).toBe('secret');
+    expect(capturedInit[0]?.method).toBe('POST');
+    expect(capturedInit[0]?.body).toBe("SELECT 1 AS one, 'hello' AS label");
+  });
+
+  it('uses HTTPS when port is 443 even without explicit ssl flag', async () => {
+    const capturedUrls: string[] = [];
+    globalThis.fetch = vi.fn(async (url: RequestInfo | URL) => {
+      capturedUrls.push(String(url));
+      return new Response(JSON.stringify({ meta: [], data: [], rows: 0 }), { status: 200 });
+    }) as typeof fetch;
+
+    await client.executeQuery(clickhouseConn({ properties: { password: 'p' } }), 'SELECT 1');
+
+    expect(capturedUrls[0].startsWith('https://')).toBe(true);
+  });
+
+  it('uses HTTP when SSL explicitly disabled and non-TLS port', async () => {
+    const capturedUrls: string[] = [];
+    globalThis.fetch = vi.fn(async (url: RequestInfo | URL) => {
+      capturedUrls.push(String(url));
+      return new Response(JSON.stringify({ meta: [], data: [], rows: 0 }), { status: 200 });
+    }) as typeof fetch;
+
+    await client.executeQuery(
+      clickhouseConn({ port: 8123, properties: { ssl: 'false' } }),
+      'SELECT 1'
+    );
+
+    expect(capturedUrls[0].startsWith('http://')).toBe(true);
+    expect(capturedUrls[0]).toContain(':8123');
+  });
+
+  it('surfaces ClickHouse error responses as thrown errors', async () => {
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response("Code: 62. DB::Exception: Syntax error near 'FROM'", {
+          status: 400,
+        })
+    ) as typeof fetch;
+
+    await expect(client.executeQuery(clickhouseConn(), 'SELECT FROM broken')).rejects.toThrow(
+      /ClickHouse HTTP 400/
+    );
+  });
+
+  it('returns empty result for DDL responses with empty body', async () => {
+    globalThis.fetch = vi.fn(async () => new Response('', { status: 200 })) as typeof fetch;
+
+    const result = await client.executeQuery(
+      clickhouseConn(),
+      'CREATE TABLE t (x Int32) ENGINE = Memory'
+    );
+    expect(result).toEqual({
+      columns: [],
+      rows: [],
+      rowCount: 0,
+      executionTime: expect.any(Number),
+    });
+  });
+
+  it('throws a clear error for unsupported drivers instead of attempting a CLI fallback', async () => {
+    const oracleConn: DatabaseConnection = {
+      id: 'oracle-1',
+      name: 'orcl',
+      driver: 'oracle_thin',
+      url: 'jdbc:oracle:thin:@//x:1521/ORCL',
+    };
+
+    await expect(client.executeQuery(oracleConn, 'SELECT 1 FROM dual')).rejects.toThrow(
+      /driver "oracle_thin" is not supported/
+    );
+  });
+});


### PR DESCRIPTION
## Summary

DBeaver 25 removed the `-o` and `-of` CLI flags that `executeViaCli` (the fallback used for drivers without a native implementation) and `exportData` both rely on. On DBeaver 25+ those flags are silently ignored — DBeaver opens the UI, connects to the datasource, and never exits — so every query through the CLI fallback times out at 30 s (`DBeaver execution timed out after 30000ms`), and `export_data` hits the same hang. Drivers routed through the fallback (Oracle, ClickHouse pre-patch, etc.) are effectively broken on DBeaver 25+.

Verified repro on DBeaver **26.0.3** against a ClickHouse datasource: every `test_connection` / `execute_query` fails with the timeout above. The `dbeaver-help` allow-list no longer contains `-o` or `-of`, and DBeaver prints `Parameter(s) -o -of csv cannot be specified after 'dbeaver'` to its debug log before falling through to the UI.

## Changes

- **Add a native ClickHouse driver** using the ClickHouse HTTP interface (`default_format=JSON`). TLS is selected when `ssl=true` is set on the DBeaver connection or when the port is 443/8443. Auth via `X-ClickHouse-User` / `X-ClickHouse-Key` headers. Handles the `clickhouse-ssl` handler block and the nested `properties.properties.ssl` layout that DBeaver writes into `data-sources.json`.
- **Remove the DBeaver CLI query fallback** (`executeViaCli`, `executeCli`, `isCliAvailable`, `parseCSVOutput`, `cleanupFiles`). Unsupported drivers now fail fast with a clear error listing the natively supported drivers (PostgreSQL + compatibles, MySQL/MariaDB, MSSQL, SQLite, ClickHouse) instead of hanging for the full timeout.
- **Route `exportData` through the native drivers.** CSV/JSON is produced in-process via the existing `convertToCSV` helper, so export no longer depends on the broken CLI path.
- Drop the unused `executablePath` field and the `csv-parser` usage in `workspace-client.ts`. The constructor's first parameter is preserved (as `_executablePath`) so existing callers that pass it continue to compile.

Net code delta: **+135 / −180** lines (dead CLI plumbing removed).

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm test` — 49 tests pass (was 43; added 6 new for `workspace-client.test.ts`)
- [x] New tests cover: ClickHouse URL/auth construction, HTTPS auto-detect by port, explicit SSL disable, error-body surfacing, DDL empty-body handling, fail-fast error for unsupported drivers.
- [x] End-to-end verified against a real DBeaver 26.0.3 workspace with ClickHouse (HTTPS:443), MySQL 8, and two PostgreSQL connections. All four resolve `test_connection` and `SELECT 1` successfully after the patch; all four timed out at 30 s before it (MySQL/Postgres were only unaffected because they already had native branches — the ClickHouse connection was the original repro).
- [x] Unsupported driver (synthetic `oracle_thin`) now throws `Database driver "oracle_thin" is not supported...` immediately instead of hanging.

## Notes

- The CHANGELOG gets an `[Unreleased]` block; happy to land under a specific version header instead if you prefer.
- The full `DatabaseConnection.properties` type is `Record<string, string>` today, but the `clickhouse-ssl` handlers block is an object. The ClickHouse driver reads through a pair of `unknown` casts for that case — matches how the existing Postgres branch handles `handlers.postgre_ssl`.
- No new runtime dependencies; `fetch` is built-in on Node ≥18, which is already the minimum in `engines.node`.