### PR TITLE
fix(mssql): read encrypt/trustServerCertificate from DBeaver connection properties

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "omnisql-mcp",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "omnisql-mcp",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.2",
@@ -1721,7 +1721,6 @@
       "integrity": "sha512-npiaib8XzbjtzS2N4HlqPvlpxpmZ14FjSJrteZpPxGUaYPlvhzlzUZ4mZyABo0EFrOWnvyd0Xxroq//hKhtAWg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.0",
         "@typescript-eslint/types": "8.53.0",
@@ -2120,7 +2119,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2893,7 +2891,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3245,7 +3242,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -4921,7 +4917,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.17.0.tgz",
       "integrity": "sha512-SRl6PbO7zqhD5bZ6lVtEFWknVeWv6Eab+PKzowWTEAce5MFiHTcSdi2N9M9m7VYAv1Hc3OOCxSka3hPBYoXHJA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.10.0",
         "pg-pool": "^3.11.0",
@@ -6062,7 +6057,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6154,7 +6148,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6329,7 +6322,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6343,7 +6335,6 @@
       "integrity": "sha512-FQMeF0DJdWY0iOnbv466n/0BudNdKj1l5jYgl5JVTwjSsZSlqyXFt/9+1sEyhR6CLowbZpV7O1sCHrzBhucKKg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.17",
         "@vitest/mocker": "4.0.17",
@@ -6680,7 +6671,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/pools/connection-pool.ts
+++ b/src/pools/connection-pool.ts
@@ -197,6 +197,13 @@ export class ConnectionPoolManager {
 
     const host = connection.host || 'localhost';
     const isAzure = host.includes('.database.windows.net');
+    const props = connection.properties || {};
+    const nestedProps = (props['properties'] as unknown as Record<string, string>) || {};
+    const encryptProp = props['encrypt'] ?? nestedProps['encrypt'];
+    const trustCertProp = props['trustServerCertificate'] ?? nestedProps['trustServerCertificate'];
+    const encrypt = encryptProp !== undefined ? encryptProp === 'true' : isAzure;
+    const trustServerCertificate =
+      trustCertProp !== undefined ? trustCertProp === 'true' : !isAzure;
 
     const pool = new sql.ConnectionPool({
       server: host,
@@ -211,8 +218,8 @@ export class ConnectionPoolManager {
         acquireTimeoutMillis: this.config.acquireTimeoutMs,
       },
       options: {
-        encrypt: isAzure,
-        trustServerCertificate: !isAzure,
+        encrypt,
+        trustServerCertificate,
       },
     });
 

--- a/src/workspace-client.ts
+++ b/src/workspace-client.ts
@@ -442,6 +442,13 @@ export class WorkspaceClient {
     }
 
     const isAzure = host.includes('.database.windows.net');
+    const props = connection.properties || {};
+    const nestedProps = (props['properties'] as unknown as Record<string, string>) || {};
+    const encryptProp = props['encrypt'] ?? nestedProps['encrypt'];
+    const trustCertProp = props['trustServerCertificate'] ?? nestedProps['trustServerCertificate'];
+    const encrypt = encryptProp !== undefined ? encryptProp === 'true' : isAzure;
+    const trustServerCertificate =
+      trustCertProp !== undefined ? trustCertProp === 'true' : !isAzure;
     const config = {
       user,
       password,
@@ -449,8 +456,8 @@ export class WorkspaceClient {
       port,
       database,
       options: {
-        encrypt: isAzure,
-        trustServerCertificate: !isAzure,
+        encrypt,
+        trustServerCertificate,
       },
     };
 


### PR DESCRIPTION
## Problem

When connecting to a SQL Server instance that requires encryption (e.g. AWS RDS), the connection fails with:

```
Server requires encryption, set 'encrypt' config option to true.
```

Both `createMssqlPool` and `executeSQLServerQuery` hardcode `encrypt` and `trustServerCertificate` based on Azure hostname detection:

```ts
const isAzure = host.includes('.database.windows.net');
options: {
  encrypt: isAzure,               // false for non-Azure hosts
  trustServerCertificate: !isAzure,
}
```

This ignores any encryption settings configured in DBeaver, breaking connections to non-Azure SQL Server instances that require encryption.

## Fix

Read `encrypt` and `trustServerCertificate` from DBeaver's connection properties first, falling back to Azure detection when not set. The fix checks both the top-level properties and the nested `properties` block (where DBeaver stores driver properties in `data-sources.json`):

```ts
const nestedProps = (props['properties'] as unknown as Record<string, string>) || {};
const encryptProp = props['encrypt'] ?? nestedProps['encrypt'];
const trustCertProp = props['trustServerCertificate'] ?? nestedProps['trustServerCertificate'];
const encrypt = encryptProp !== undefined ? encryptProp === 'true' : isAzure;
const trustServerCertificate = trustCertProp !== undefined ? trustCertProp === 'true' : !isAzure;
```

This pattern mirrors how Postgres SSL config is already read from DBeaver properties.

## Testing

Verified against an AWS RDS SQL Server instance with `encrypt=true` and `trustServerCertificate=true` set in DBeaver — connection succeeds after this fix.