### PR TITLE
fix: add error handler for sqlite3 spawn to prevent process crash

### DIFF
--- a/src/workspace-client.ts
+++ b/src/workspace-client.ts
@@ -290,6 +290,10 @@ export class WorkspaceClient {
         stdio: ['pipe', 'pipe', 'pipe'],
       });
 
+      proc.on('error', (err) => {
+        reject(new Error(`sqlite3 CLI not found: ${err.message}`));
+      });
+
       let output = '';
       let error = '';
 


### PR DESCRIPTION
When sqlite3 CLI is not installed, spawn() throws an error that was previously unhandled, crashing the entire MCP server process. This adds a proc.on('error') handler to gracefully catch the error and reject the promise with a meaningful error message instead.

## Summary
<!-- Brief description of changes -->

## Changes
-

## Related Issues
<!-- Fixes #123 -->

## Checklist
- [ ] Tests pass locally
- [ ] Linting passes
- [ ] Documentation updated (if needed)
- [ ] Breaking changes documented
