### PR TITLE
feat: add OMNISQL_PROJECT env var to support custom DB client project names

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Add to Cursor Settings > MCP Servers:
 |----------|-------------|---------|
 | `OMNISQL_CLI_PATH` | Path to external DB client CLI (used for unsupported-driver fallback) | Unset |
 | `OMNISQL_WORKSPACE` | Path to local DB client workspace directory | OS default |
+| `OMNISQL_PROJECT` | Name of the DB client project/workspace folder (e.g. custom-named DBeaver project) | `General` |
 | `OMNISQL_TIMEOUT` | Query timeout (ms) | `30000` |
 | `OMNISQL_DEBUG` | Enable debug logging | `false` |
 | `OMNISQL_READ_ONLY` | Disable all write operations | `false` |
@@ -203,6 +204,10 @@ Restrict which workspace connections are visible. Accepts connection IDs or disp
 Supports both configuration formats written by DBeaver-compatible DB clients:
 - Legacy: XML config in `.metadata/.plugins/org.jkiss.dbeaver.core/`
 - Modern: JSON config in `General/.dbeaver/`
+
+The project/workspace folder name (`General` by default) is configurable via `OMNISQL_PROJECT`,
+so workspaces using a custom or renamed DBeaver project (e.g. `DataPlatform`) are discovered
+without needing to rename the project or symlink the folder.
 
 Credentials are automatically decrypted from the workspace `credentials-config.json`.
 

--- a/docs-site/docs/getting-started/configuration.md
+++ b/docs-site/docs/getting-started/configuration.md
@@ -59,6 +59,7 @@ To use OmniSQL MCP with Claude Desktop, add the following to your configuration 
 ### Core Variables
 - `OMNISQL_CLI_PATH`: Path to external DB client CLI binary (required only for the unsupported-driver CLI fallback)
 - `OMNISQL_WORKSPACE`: Path to your local DB client workspace directory (defaults to the OS-standard location)
+- `OMNISQL_PROJECT`: Name of the DB client project/workspace folder, for custom-named or renamed DBeaver projects (default: `General`)
 - `OMNISQL_TIMEOUT`: Query timeout in milliseconds (default: 30000)
 - `OMNISQL_DEBUG`: Set to `true` to enable debug logging
 

--- a/docs-site/docs/getting-started/installation.md
+++ b/docs-site/docs/getting-started/installation.md
@@ -96,6 +96,7 @@ Configure the server behavior with these environment variables:
 
 - `OMNISQL_CLI_PATH`: Path to external DB client CLI (for unsupported-driver fallback)
 - `OMNISQL_WORKSPACE`: Path to local DB client workspace directory
+- `OMNISQL_PROJECT`: Name of the DB client project/workspace folder (default: `General`)
 - `OMNISQL_TIMEOUT`: Query timeout in milliseconds (default: 30000)
 - `OMNISQL_DEBUG`: Enable debug logging (true/false)
 

--- a/examples/claude-desktop-config.json
+++ b/examples/claude-desktop-config.json
@@ -46,6 +46,7 @@
     "environment_variables": {
       "OMNISQL_CLI_PATH": "Path to external DB client CLI (for unsupported-driver fallback)",
       "OMNISQL_WORKSPACE": "Custom workspace path (OS default if not set)",
+      "OMNISQL_PROJECT": "Name of the DB client project/workspace folder (default: 'General')",
       "OMNISQL_TIMEOUT": "Query timeout in milliseconds (default: 30000)",
       "OMNISQL_DEBUG": "Enable debug logging (true/false)",
       "OMNISQL_READ_ONLY": "Disable all write operations (true/false)",

--- a/src/config-parser.ts
+++ b/src/config-parser.ts
@@ -12,6 +12,9 @@ const parseXML = promisify(parseString);
 const WORKSPACE_AES_KEY = Buffer.from('babb4a9f774ab853c96c2d653dfe544a', 'hex');
 const WORKSPACE_AES_IV = Buffer.alloc(16, 0);
 
+// Default project/workspace folder name used by the local DB client (DBeaver-compatible)
+const DEFAULT_PROJECT_NAME = 'General';
+
 export class WorkspaceConfigParser {
   private config: WorkspaceConfig;
   private isNewFormat: boolean = false;
@@ -19,10 +22,12 @@ export class WorkspaceConfigParser {
   constructor(config: WorkspaceConfig = {}) {
     const workspacePath = config.workspacePath ?? this.getDefaultWorkspacePath();
     const debug = config.debug ?? false;
+    const projectName = config.projectName ?? DEFAULT_PROJECT_NAME;
     this.config = {
       ...config,
       workspacePath,
       debug,
+      projectName,
     };
 
     // Detect which workspace config format is in use (new JSON vs legacy XML)
@@ -32,7 +37,7 @@ export class WorkspaceConfigParser {
   private detectNewFormat(): boolean {
     const newFormatPath = path.join(
       this.config.workspacePath!,
-      'General',
+      this.config.projectName!,
       '.dbeaver',
       'data-sources.json'
     );
@@ -55,7 +60,11 @@ export class WorkspaceConfigParser {
     }
 
     // If neither exists, check for new format directory structure
-    const newFormatDir = path.join(this.config.workspacePath!, 'General', '.dbeaver');
+    const newFormatDir = path.join(
+      this.config.workspacePath!,
+      this.config.projectName!,
+      '.dbeaver'
+    );
     const oldFormatDir = path.join(this.config.workspacePath!, '.metadata');
 
     // Prefer new format if its directory structure exists
@@ -88,7 +97,12 @@ export class WorkspaceConfigParser {
 
   private getConnectionsFilePath(): string {
     if (this.isNewFormat) {
-      return path.join(this.config.workspacePath!, 'General', '.dbeaver', 'data-sources.json');
+      return path.join(
+        this.config.workspacePath!,
+        this.config.projectName!,
+        '.dbeaver',
+        'data-sources.json'
+      );
     } else {
       return path.join(
         this.config.workspacePath!,
@@ -104,7 +118,7 @@ export class WorkspaceConfigParser {
     if (this.isNewFormat) {
       return path.join(
         this.config.workspacePath!,
-        'General',
+        this.config.projectName!,
         '.dbeaver',
         'credentials-config.json'
       );
@@ -126,7 +140,12 @@ export class WorkspaceConfigParser {
       // Try the alternative format if the detected format file doesn't exist
       const alternativeFormat = !this.isNewFormat;
       const alternativeFile = alternativeFormat
-        ? path.join(this.config.workspacePath!, 'General', '.dbeaver', 'data-sources.json')
+        ? path.join(
+            this.config.workspacePath!,
+            this.config.projectName!,
+            '.dbeaver',
+            'data-sources.json'
+          )
         : path.join(
             this.config.workspacePath!,
             '.metadata',
@@ -357,7 +376,7 @@ export class WorkspaceConfigParser {
     const workspacePath = this.config.workspacePath!;
 
     if (this.isNewFormat) {
-      const newFormatPath = path.join(workspacePath, 'General', '.dbeaver');
+      const newFormatPath = path.join(workspacePath, this.config.projectName!, '.dbeaver');
       return fs.existsSync(workspacePath) && fs.existsSync(newFormatPath);
     } else {
       const metadataPath = path.join(workspacePath, '.metadata');

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,6 +108,7 @@ class OmniSQLMCPServer {
       timeout: parseInt(process.env.OMNISQL_TIMEOUT || '30000'),
       executablePath: process.env.OMNISQL_CLI_PATH,
       workspacePath: process.env.OMNISQL_WORKSPACE,
+      projectName: process.env.OMNISQL_PROJECT,
     });
 
     this.workspaceClient = new WorkspaceClient(
@@ -1743,6 +1744,7 @@ Options:
 Environment Variables:
   OMNISQL_CLI_PATH             Path to local DB client CLI executable (for unsupported-driver fallback)
   OMNISQL_WORKSPACE            Path to local DB client workspace directory
+  OMNISQL_PROJECT              Name of the DB client project/workspace folder (default: "General")
   OMNISQL_TIMEOUT              Query timeout in milliseconds (default: 30000)
   OMNISQL_DEBUG                Enable debug logging (true/false)
   OMNISQL_READ_ONLY            Disable all write operations (true/false)

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,6 +69,11 @@ export interface WorkspaceConfig {
   executablePath?: string;
   timeout?: number;
   debug?: boolean;
+  /**
+   * Name of the DB client project/workspace folder to read connections from
+   * (e.g. a custom-named DBeaver project instead of the default "General").
+   */
+  projectName?: string;
 }
 
 export interface ConnectionTest {

--- a/tests/config-parser.test.ts
+++ b/tests/config-parser.test.ts
@@ -37,4 +37,33 @@ describe('WorkspaceConfigParser', () => {
       expect(connections).toEqual([]);
     });
   });
+
+  describe('projectName', () => {
+    it('should default to General when projectName is not provided', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+
+      const { WorkspaceConfigParser } = await import('../src/config-parser.js');
+      const parser = new WorkspaceConfigParser({ workspacePath: '/Users/test/workspace6' });
+
+      const debugInfo = parser.getDebugInfo() as { connectionsFile: string };
+      expect(debugInfo.connectionsFile).toBe(
+        '/Users/test/workspace6/General/.dbeaver/data-sources.json'
+      );
+    });
+
+    it('should use a custom projectName when provided', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+
+      const { WorkspaceConfigParser } = await import('../src/config-parser.js');
+      const parser = new WorkspaceConfigParser({
+        workspacePath: '/Users/test/workspace6',
+        projectName: 'DataPlatform',
+      });
+
+      const debugInfo = parser.getDebugInfo() as { connectionsFile: string };
+      expect(debugInfo.connectionsFile).toBe(
+        '/Users/test/workspace6/DataPlatform/.dbeaver/data-sources.json'
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Summary

`WorkspaceConfigParser` hardcodes the DB client (DBeaver) project/workspace folder name to `'General'` in 6 places. Any workspace that uses a custom or renamed project name (e.g. a real-world project literally named `DataPlatform`) returns **zero connections** from `list_connections`, with no way to configure it — `OMNISQL_WORKSPACE` only overrides the workspace *root*, not the project folder underneath it, and `OMNISQL_CLI_PATH` is unrelated (it only feeds the CLI query-execution fallback, not connection discovery).

I hit this directly: my real DBeaver project is named `DataPlatform`, containing 9 real connections across several folders. `list_connections` returned `[]` until I worked around it locally with a symlink (`~/Library/DBeaverData/workspace6/General -> .../DataPlatform`). This PR removes the need for that workaround.

## Changes
- Add optional `projectName?: string` to `WorkspaceConfig` (`src/types.ts`)
- Add `DEFAULT_PROJECT_NAME = 'General'` constant in `src/config-parser.ts`; constructor now does `config.projectName ?? DEFAULT_PROJECT_NAME`
- Replace all 6 hardcoded `'General'` literals in `WorkspaceConfigParser` with `this.config.projectName!`: `detectNewFormat()` (x2), `getConnectionsFilePath()`, `getCredentialsFilePath()`, `parseConnections()` fallback path, `isWorkspaceValid()`
- Wire new `OMNISQL_PROJECT` env var into the `WorkspaceConfigParser` instantiation in `src/index.ts`, and document it in the CLI `--help` text
- Add test coverage in `tests/config-parser.test.ts` (asserts default `'General'` path vs. a custom `projectName` path via `getDebugInfo()`)
- Document `OMNISQL_PROJECT` in `README.md` (env var table + "Workspace Format Support" section), `docs-site/docs/getting-started/configuration.md`, `docs-site/docs/getting-started/installation.md`, and `examples/claude-desktop-config.json`

Fully backward compatible — default behavior (`'General'`) is unchanged when the new env var/config field is not set.

## Related Issues
None filed — found and fixed while setting this MCP server up against a real workspace.

## Checklist
- [x] Tests pass locally (`npm test` — 45/45 passing, including 2 new `projectName` tests)
- [x] Linting passes (`npm run lint`, `npm run build` — clean)
- [x] Documentation updated (README, docs-site pages, Claude Desktop config example)
- [x] Breaking changes documented (none — fully backward compatible, defaults preserve current `'General'` behavior)
