### PR TITLE
add compatibility with aws iam auth custom jdbc driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **AWS RDS IAM authentication**: Connections that authenticate with an IAM token instead of a stored password now work natively, for both PostgreSQL and MySQL. Tokens are minted with `aws rds generate-db-auth-token` (so SSO and role-chained profiles work as configured), cached for 13 minutes under their 15-minute lifetime, and re-minted per physical connection so long-lived pools keep working. TLS is forced for these connections, as RDS requires. Recognised from AWS Advanced JDBC Wrapper properties (`wrapperPlugins: "iam"`) or an `iam` auth model.
+- **Database username derivation**: When an IAM connection records no username, it is derived from the caller's AWS identity — either the per-developer role name (`<profile>-<user>`) or the assumed SSO session name.
+- **Custom driver support**: Drivers with an opaque id (a UUID, for instance) now route to the right native driver by falling back to the connection's `provider` and then the JDBC URL sub-protocol, including wrapped protocols such as `jdbc:aws-wrapper:postgresql://`. Previously any such driver fell through to the CLI fallback and failed.
+- New `OMNISQL_AWS_CLI_PATH` and `OMNISQL_IAM_TOKEN_TIMEOUT` environment variables.
+
+### Fixed
+- **MySQL TLS options were read from the wrong place**: only top-level connection properties were checked, so the nested `properties` block written by the JSON workspace format was ignored. PostgreSQL already handled both.
+- **MySQL `ssl-mode` semantics**: `REQUIRED` now encrypts without validating the certificate chain, per MySQL's documented behaviour, and only the `VERIFY_CA`/`VERIFY_IDENTITY` modes verify it. Previously `REQUIRED` implied full verification, which fails against managed engines whose CA is not in the system trust store. `REQUIRED`/`DISABLED` spellings are also recognised now.
+- **Host, port and database are backfilled from the JDBC URL** when a connection config omits them.
+- Unsupported-driver errors now name the raw driver id and provider alongside the resolved driver, instead of only the resolved one.
+
+### Internal
+- TLS resolution is now shared between the direct-query and pooled connection paths, which previously read different property locations and disagreed about what `require` meant.
+
 ## [2.0.1] - 2026-04-20
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -19,10 +19,13 @@ Universal database MCP server — give AI assistants read/write access to your d
 
 **Other databases**: Fall back to an external CLI configured via `OMNISQL_CLI_PATH`. Results vary by CLI.
 
+**Custom drivers** wrapping any of the above are detected automatically — see [Custom and IAM-Authenticated Drivers](#custom-and-iam-authenticated-drivers).
+
 ## Features
 
 - Reuses connections already configured in your local DB client workspace — no duplicate setup
 - Native query execution for PostgreSQL, MySQL/MariaDB, SQLite, SQL Server
+- AWS RDS IAM authentication, including custom drivers built on the AWS Advanced JDBC Wrapper
 - Connection pooling with configurable pool size and timeouts
 - Transaction support (BEGIN/COMMIT/ROLLBACK)
 - Query execution plan analysis (EXPLAIN)
@@ -104,6 +107,8 @@ Add to Cursor Settings > MCP Servers:
 | `OMNISQL_POOL_MAX` | Maximum connections per pool | `10` |
 | `OMNISQL_POOL_IDLE_TIMEOUT` | Idle connection timeout (ms) | `30000` |
 | `OMNISQL_POOL_ACQUIRE_TIMEOUT` | Connection acquire timeout (ms) | `10000` |
+| `OMNISQL_AWS_CLI_PATH` | Path to the AWS CLI (used for RDS IAM authentication) | `aws` |
+| `OMNISQL_IAM_TOKEN_TIMEOUT` | Timeout for minting an RDS IAM auth token (ms) | `20000` |
 
 ### Read-Only Mode
 
@@ -205,6 +210,43 @@ Supports both configuration formats written by DBeaver-compatible DB clients:
 - Modern: JSON config in `General/.dbeaver/`
 
 Credentials are automatically decrypted from the workspace `credentials-config.json`.
+
+## Custom and IAM-Authenticated Drivers
+
+### Custom drivers
+
+Native routing normally keys off the driver id (`postgres-jdbc`, `mysql8`). Custom drivers often use an
+opaque id instead — a UUID, say — which names no engine. Those connections are resolved by falling back
+to the connection's `provider` (`postgresql`, `mysql`, …) and then to the JDBC URL's sub-protocol,
+including wrapped ones such as `jdbc:aws-wrapper:postgresql://…`. A custom driver wrapping a supported
+engine therefore works with no extra configuration.
+
+If an engine still cannot be identified, the resulting error names both the driver id and the provider
+so you can see what was missing.
+
+### AWS RDS IAM authentication
+
+Connections that authenticate with an RDS IAM token instead of a stored password are detected and
+handled automatically. Both shapes are recognised:
+
+- **AWS Advanced JDBC Wrapper** drivers, which record `wrapperPlugins: "iam"` alongside `awsProfile`
+  and `iamRegion`.
+- The DB client's own **AWS IAM auth models**.
+
+For these connections OmniSQL:
+
+1. Mints a token with `aws rds generate-db-auth-token` (via the AWS CLI, so SSO and role-chained
+   profiles work as configured) and uses it as the password.
+2. Caches each token for 13 minutes, under its 15-minute lifetime, and re-mints per physical
+   connection so long-lived pools keep working.
+3. Forces TLS, which RDS requires for IAM tokens.
+4. Resolves the database username from the connection when present. Where it is absent, the username is
+   derived from your AWS identity: either the per-developer role name (`<profile>-<user>`) or the
+   assumed SSO session name.
+
+**Requirements**: the AWS CLI on `PATH` (or `OMNISQL_AWS_CLI_PATH`), a valid session for the
+connection's profile (`aws sso login --profile <profile>`), and network reachability to the endpoint.
+An expired SSO session produces an error naming the profile to re-authenticate.
 
 ## Development
 

--- a/src/auth/connection-props.ts
+++ b/src/auth/connection-props.ts
@@ -1,0 +1,41 @@
+import { DatabaseConnection } from '../types.js';
+
+/**
+ * Read a connection property, looking through both levels the workspace uses.
+ *
+ * The JSON workspace format keeps engine/driver properties nested under a
+ * `properties` key inside the connection configuration, while the legacy XML
+ * format keeps everything flat. Nested values win, since that is where
+ * driver-specific configuration lives.
+ *
+ * Names are matched case-insensitively because casing varies by driver
+ * (Postgres uses `sslmode`, MySQL uses `sslMode`). Nested objects are skipped
+ * so a container never masks a scalar of the same name.
+ */
+export function readConnectionProp(
+  connection: DatabaseConnection,
+  ...names: string[]
+): string | undefined {
+  const props = (connection.properties ?? {}) as Record<string, unknown>;
+  const nested = (props['properties'] as Record<string, unknown> | undefined) ?? {};
+
+  for (const name of names) {
+    const wanted = name.toLowerCase();
+    for (const source of [nested, props]) {
+      const key = Object.keys(source).find((k) => k.toLowerCase() === wanted);
+      if (key === undefined) {
+        continue;
+      }
+      const value = source[key];
+      if (value === undefined || value === null || typeof value === 'object') {
+        continue;
+      }
+      const str = String(value);
+      if (str.length > 0) {
+        return str;
+      }
+    }
+  }
+
+  return undefined;
+}

--- a/src/auth/iam-auth.ts
+++ b/src/auth/iam-auth.ts
@@ -1,0 +1,415 @@
+/**
+ * AWS RDS IAM database authentication.
+ *
+ * Connections created for IAM auth carry no stored credential - the auth token
+ * itself authenticates, and is minted per connection and expires after 15
+ * minutes. This module detects such connections, resolves the DB username, and
+ * mints tokens via the AWS CLI (which handles SSO and role-chained profiles).
+ *
+ * Recognised shapes:
+ *  - AWS Advanced JDBC Wrapper drivers, which record `wrapperPlugins: "iam"`
+ *    alongside `awsProfile`/`iamRegion` and a `jdbc:aws-wrapper:<engine>://` URL.
+ *  - The DB client's own AWS IAM auth models, which set an `iam`-flavoured
+ *    `auth-model`.
+ */
+
+import { spawn } from 'child_process';
+import { DatabaseConnection } from '../types.js';
+import { readConnectionProp } from './connection-props.js';
+
+/** Tokens valid for 15 minutes; refresh early so in-flight connects never race expiry. */
+const TOKEN_TTL_MS = 13 * 60 * 1000;
+
+const DEFAULT_CLI_TIMEOUT_MS = 20000;
+
+/** Wrapper plugin codes that make the password an IAM token. */
+const IAM_PLUGIN_CODES = ['iam', 'federatedauth', 'okta', 'adfs'];
+
+export interface IamTarget {
+  host: string;
+  port: number;
+  user: string;
+  region?: string;
+  profile?: string;
+}
+
+/** Runs the AWS CLI and resolves with stdout. Injectable for tests. */
+export type AwsCommandRunner = (args: string[], timeoutMs: number) => Promise<string>;
+
+export interface IamAuthOptions {
+  runner?: AwsCommandRunner;
+  timeoutMs?: number;
+  debug?: boolean;
+}
+
+interface CacheEntry {
+  token: string;
+  expiresAt: number;
+}
+
+const tokenCache = new Map<string, CacheEntry>();
+const usernameCache = new Map<string, string>();
+
+/** Clear cached tokens and derived usernames. Exposed for tests and long-lived processes. */
+export function clearIamAuthCache(): void {
+  tokenCache.clear();
+  usernameCache.clear();
+}
+
+const readProp = readConnectionProp;
+
+/**
+ * True when this connection authenticates with an RDS IAM token rather than a
+ * stored password.
+ */
+export function isIamAuthConnection(connection: DatabaseConnection): boolean {
+  const plugins = readProp(connection, 'wrapperPlugins', 'wrapperPluginCodes');
+  if (plugins) {
+    const codes = plugins
+      .split(',')
+      .map((c) => c.trim().toLowerCase())
+      .filter(Boolean);
+    if (codes.some((code) => IAM_PLUGIN_CODES.includes(code))) {
+      return true;
+    }
+  }
+
+  const authModel = readProp(connection, 'auth-model', 'authModel', 'authModelId');
+  if (authModel && authModel.toLowerCase().includes('iam')) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Extract the AWS region from an RDS endpoint.
+ *
+ * `db.cluster-abc123.us-gov-east-1.rds.amazonaws.com` -> `us-gov-east-1`
+ */
+export function regionFromRdsHost(host: string): string | undefined {
+  const parts = host.toLowerCase().split('.');
+  const rdsIdx = parts.lastIndexOf('rds');
+  if (rdsIdx > 0) {
+    const candidate = parts[rdsIdx - 1];
+    // Regions look like us-east-1 / us-gov-east-1 / ap-southeast-2.
+    if (/^[a-z]{2}(-[a-z]+)+-\d+$/.test(candidate)) {
+      return candidate;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Session names the SDK generates itself, which say nothing about who is calling.
+ */
+function isGeneratedSessionName(sessionName: string): boolean {
+  return /(^|-)session-\d+$/i.test(sessionName);
+}
+
+/**
+ * Derive the DB username from an STS caller identity ARN.
+ *
+ * Two shapes matter:
+ *
+ *  - A per-developer role assumed through a generated profile. The role is named
+ *    `<profile>-<dbuser>` (`example-int-db-devuser` behind profile
+ *    `example-int-db`), while the session name is SDK-generated
+ *    (`botocore-session-1785446405`) and therefore useless. Strip the profile
+ *    prefix off the role name.
+ *  - A directly assumed SSO role, whose session name *is* the user:
+ *    `.../assumed-role/AWSReservedSSO_Admin_x/devuser@example.com` -> `devuser`.
+ */
+export function dbUserFromCallerArn(arn: string, profile?: string): string | undefined {
+  const assumed = arn.match(/assumed-role\/([^/]+)\/(.+)$/);
+  if (assumed) {
+    const [, roleName, sessionName] = assumed;
+
+    if (profile && roleName.toLowerCase().startsWith(`${profile.toLowerCase()}-`)) {
+      const fromRole = roleName.slice(profile.length + 1);
+      if (fromRole) {
+        return fromRole;
+      }
+    }
+
+    if (!isGeneratedSessionName(sessionName)) {
+      return sessionName.split('@')[0] || undefined;
+    }
+
+    return undefined;
+  }
+
+  const iamUser = arn.match(/:user\/(?:.*\/)?(.+)$/);
+  if (iamUser) {
+    return iamUser[1].split('@')[0] || undefined;
+  }
+
+  return undefined;
+}
+
+function awsCliPath(): string {
+  return process.env.OMNISQL_AWS_CLI_PATH || 'aws';
+}
+
+/** Default runner: spawn the AWS CLI with an argument array (never a shell). */
+const spawnAwsCli: AwsCommandRunner = (args, timeoutMs) => {
+  return new Promise<string>((resolve, reject) => {
+    const exe = awsCliPath();
+    let proc;
+    try {
+      proc = spawn(exe, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    } catch (error) {
+      reject(
+        new Error(`Failed to run "${exe}": ${error instanceof Error ? error.message : error}`)
+      );
+      return;
+    }
+
+    let stdout = '';
+    let stderr = '';
+    let settled = false;
+
+    const timeoutId = setTimeout(() => {
+      settled = true;
+      proc.kill('SIGTERM');
+      reject(new Error(`AWS CLI timed out after ${timeoutMs}ms: aws ${args[0]} ${args[1] ?? ''}`));
+    }, timeoutMs);
+
+    proc.stdout?.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+    proc.stderr?.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+
+    proc.on('error', (error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeoutId);
+      const hint =
+        (error as NodeJS.ErrnoException).code === 'ENOENT'
+          ? ` AWS CLI not found at "${exe}" - install it or set OMNISQL_AWS_CLI_PATH.`
+          : '';
+      reject(new Error(`Failed to run AWS CLI: ${error.message}.${hint}`));
+    });
+
+    proc.on('close', (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeoutId);
+      if (code === 0) {
+        resolve(stdout);
+        return;
+      }
+      reject(new Error(stderr.trim() || stdout.trim() || `AWS CLI exited with code ${code}`));
+    });
+  });
+};
+
+/**
+ * Turn a raw AWS CLI failure into something the user can act on.
+ *
+ * Expired SSO sessions are by far the most common cause and the CLI's own
+ * message does not name the profile to re-authenticate.
+ */
+function decorateAwsError(error: unknown, profile?: string): Error {
+  const message = error instanceof Error ? error.message : String(error);
+  const lower = message.toLowerCase();
+
+  const ssoExpired =
+    lower.includes('token has expired') ||
+    lower.includes('error loading sso token') ||
+    lower.includes('sso session associated with this profile') ||
+    lower.includes('the sso access token');
+
+  if (ssoExpired) {
+    const loginTarget = profile ? ` --profile ${profile}` : '';
+    return new Error(
+      `AWS SSO session expired. Run \`aws sso login${loginTarget}\` and retry. (${message})`
+    );
+  }
+
+  return new Error(message);
+}
+
+/**
+ * Resolve the DB username for an IAM connection, deriving it from the caller's
+ * identity when the connection config does not record one.
+ */
+export async function resolveIamUsername(
+  connection: DatabaseConnection,
+  options: IamAuthOptions = {}
+): Promise<string> {
+  const configured = connection.user || readProp(connection, 'user', 'username');
+  if (configured) {
+    return configured;
+  }
+
+  const profile = readProp(connection, 'awsProfile', 'profile') || process.env.AWS_PROFILE;
+  const cacheKey = profile ?? '<default>';
+  const cached = usernameCache.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  const runner = options.runner ?? spawnAwsCli;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_CLI_TIMEOUT_MS;
+
+  const args = ['sts', 'get-caller-identity', '--output', 'json'];
+  if (profile) {
+    args.push('--profile', profile);
+  }
+
+  let stdout: string;
+  try {
+    stdout = await runner(args, timeoutMs);
+  } catch (error) {
+    throw new Error(
+      `Connection "${connection.name}" uses AWS IAM authentication but records no database ` +
+        `username, and deriving one from your AWS identity failed: ` +
+        `${decorateAwsError(error, profile).message}`
+    );
+  }
+
+  let arn = '';
+  try {
+    arn = String(JSON.parse(stdout).Arn ?? '');
+  } catch {
+    // fall through to the error below
+  }
+
+  const derived = arn ? dbUserFromCallerArn(arn, profile) : undefined;
+  if (!derived) {
+    throw new Error(
+      `Connection "${connection.name}" uses AWS IAM authentication but records no database ` +
+        `username, and none could be derived from AWS identity "${arn || 'unknown'}". ` +
+        `Set the username on the connection in your DB client.`
+    );
+  }
+
+  if (options.debug) {
+    console.error(`Derived IAM database username "${derived}" from ${arn}`);
+  }
+
+  usernameCache.set(cacheKey, derived);
+  return derived;
+}
+
+/**
+ * Build the host/port/user/region/profile tuple a token is minted against.
+ */
+export async function resolveIamTarget(
+  connection: DatabaseConnection,
+  defaultPort: number,
+  options: IamAuthOptions = {}
+): Promise<IamTarget> {
+  const host = connection.host || readProp(connection, 'host', 'server');
+  if (!host) {
+    throw new Error(
+      `Connection "${connection.name}" uses AWS IAM authentication but has no host configured.`
+    );
+  }
+
+  const portRaw = connection.port ?? readProp(connection, 'port');
+  const port = portRaw ? parseInt(String(portRaw), 10) : defaultPort;
+
+  const user = await resolveIamUsername(connection, options);
+  const profile = readProp(connection, 'awsProfile', 'profile') || process.env.AWS_PROFILE;
+  const region =
+    readProp(connection, 'iamRegion', 'awsRegion', 'region') ||
+    regionFromRdsHost(host) ||
+    process.env.AWS_REGION ||
+    process.env.AWS_DEFAULT_REGION;
+
+  return {
+    host,
+    port: Number.isNaN(port) ? defaultPort : port,
+    user,
+    region,
+    profile,
+  };
+}
+
+/**
+ * Mint (or reuse) an RDS IAM auth token to use as the connection password.
+ */
+export async function getIamAuthToken(
+  target: IamTarget,
+  options: IamAuthOptions = {}
+): Promise<string> {
+  const cacheKey = [
+    target.profile ?? '',
+    target.region ?? '',
+    target.host,
+    target.port,
+    target.user,
+  ].join('|');
+
+  const cached = tokenCache.get(cacheKey);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.token;
+  }
+
+  const runner = options.runner ?? spawnAwsCli;
+  const timeoutMs =
+    options.timeoutMs ??
+    parseInt(process.env.OMNISQL_IAM_TOKEN_TIMEOUT || String(DEFAULT_CLI_TIMEOUT_MS), 10);
+
+  const args = [
+    'rds',
+    'generate-db-auth-token',
+    '--hostname',
+    target.host,
+    '--port',
+    String(target.port),
+    '--username',
+    target.user,
+  ];
+  if (target.region) {
+    args.push('--region', target.region);
+  }
+  if (target.profile) {
+    args.push('--profile', target.profile);
+  }
+
+  let stdout: string;
+  try {
+    stdout = await runner(args, Number.isNaN(timeoutMs) ? DEFAULT_CLI_TIMEOUT_MS : timeoutMs);
+  } catch (error) {
+    throw decorateAwsError(error, target.profile);
+  }
+
+  const token = stdout.trim();
+  if (!token) {
+    throw new Error(
+      `AWS returned an empty RDS auth token for ${target.user}@${target.host}:${target.port}.`
+    );
+  }
+
+  tokenCache.set(cacheKey, { token, expiresAt: Date.now() + TOKEN_TTL_MS });
+
+  if (options.debug) {
+    console.error(
+      `Minted RDS IAM token for ${target.user}@${target.host}:${target.port} ` +
+        `(${token.length} chars, profile=${target.profile ?? 'default'}, region=${target.region ?? 'default'})`
+    );
+  }
+
+  return token;
+}
+
+/**
+ * Resolve the credentials for an IAM connection in one step.
+ *
+ * `password` is a freshly minted RDS auth token, named for the driver option it
+ * feeds rather than for how it was obtained.
+ */
+export async function resolveIamCredentials(
+  connection: DatabaseConnection,
+  defaultPort: number,
+  options: IamAuthOptions = {}
+): Promise<{ user: string; password: string }> {
+  const target = await resolveIamTarget(connection, defaultPort, options);
+  const authToken = await getIamAuthToken(target, options);
+  return { user: target.user, password: authToken };
+}

--- a/src/auth/ssl.ts
+++ b/src/auth/ssl.ts
@@ -1,0 +1,161 @@
+/**
+ * TLS configuration shared by the direct-query and pooled connection paths.
+ *
+ * Keeping one implementation avoids the two drifting: they previously read
+ * different property locations and disagreed about what "require" means.
+ */
+
+import fs from 'fs';
+import { DatabaseConnection } from '../types.js';
+import { readConnectionProp } from './connection-props.js';
+
+/** Modes that authenticate the server certificate, rather than merely encrypting. */
+const PG_VERIFY_MODES = ['verify-ca', 'verify-full'];
+const MYSQL_VERIFY_MODES = ['verify-ca', 'verify_ca', 'verify-full', 'verify_identity'];
+
+const PG_REQUIRE_MODES = ['require', 'required', 'true', '1', ...PG_VERIFY_MODES];
+const MYSQL_REQUIRE_MODES = [
+  'require',
+  'required',
+  'true',
+  '1',
+  'preferred',
+  'enabled',
+  'yes',
+  ...MYSQL_VERIFY_MODES,
+];
+
+const PG_DISABLE_MODES = ['disable', 'disabled', 'false', '0'];
+const MYSQL_DISABLE_MODES = ['disable', 'disabled', 'false', '0', 'none', 'off', 'no'];
+
+/** Read a PEM file, returning undefined when it is missing or unreadable. */
+function readPem(pathValue: string | undefined): string | undefined {
+  if (!pathValue) {
+    return undefined;
+  }
+  try {
+    if (fs.existsSync(pathValue)) {
+      return fs.readFileSync(pathValue).toString();
+    }
+  } catch {
+    // Unreadable cert material falls back to the default trust store.
+  }
+  return undefined;
+}
+
+function buildSslMaterial(
+  ca: string | undefined,
+  cert: string | undefined,
+  key: string | undefined
+): Record<string, string> {
+  const material: Record<string, string> = {};
+  const caPem = readPem(ca);
+  const certPem = readPem(cert);
+  const keyPem = readPem(key);
+  if (caPem) material.ca = caPem;
+  if (certPem) material.cert = certPem;
+  if (keyPem) material.key = keyPem;
+  return material;
+}
+
+/**
+ * Resolve the Postgres SSL mode declared by a connection.
+ *
+ * Besides plain properties, the workspace can express TLS through an
+ * `handlers.postgre_ssl` block, whose mere presence implies TLS.
+ */
+function postgresSslMode(connection: DatabaseConnection): string {
+  const direct = readConnectionProp(connection, 'ssl.mode', 'sslmode', 'sslMode', 'ssl');
+  if (direct) {
+    return direct.toLowerCase();
+  }
+
+  const handlers = connection.properties?.['handlers'] as unknown as
+    | Record<string, unknown>
+    | undefined;
+  const sslHandler = handlers?.['postgre_ssl'] as Record<string, unknown> | undefined;
+  if (sslHandler?.enabled) {
+    const handlerMode = (sslHandler.properties as Record<string, unknown> | undefined)?.['sslMode'];
+    return String(handlerMode ?? 'require').toLowerCase();
+  }
+
+  return '';
+}
+
+/**
+ * Build the `ssl` option for a `pg` client or pool.
+ *
+ * `iamAuth` forces TLS on, because RDS rejects IAM tokens sent in cleartext.
+ * Returns `undefined` to leave the driver at its own default.
+ */
+export function resolvePostgresSsl(
+  connection: DatabaseConnection,
+  iamAuth = false,
+  debug = false
+): Record<string, unknown> | false | undefined {
+  const sslMode = postgresSslMode(connection);
+  const disable = PG_DISABLE_MODES.includes(sslMode);
+
+  if (disable) {
+    return false;
+  }
+
+  if (!PG_REQUIRE_MODES.includes(sslMode) && !iamAuth) {
+    return undefined;
+  }
+
+  const material = buildSslMaterial(
+    readConnectionProp(connection, 'sslrootcert', 'ssl.root.cert', 'sslRootCert'),
+    readConnectionProp(connection, 'sslcert', 'ssl.cert', 'sslCert'),
+    readConnectionProp(connection, 'sslkey', 'ssl.key', 'sslKey')
+  );
+
+  const hasCa = typeof material.ca === 'string' && material.ca.length > 0;
+  const verify = PG_VERIFY_MODES.includes(sslMode);
+
+  if (verify && !hasCa && debug) {
+    console.warn(
+      'sslMode set to verify-ca/verify-full but no sslrootcert provided; using system CA store'
+    );
+  }
+
+  return { ...material, rejectUnauthorized: verify };
+}
+
+/**
+ * Build the `ssl` option for a `mysql2` connection or pool.
+ *
+ * MySQL's REQUIRED encrypts without validating the chain; only the VERIFY_*
+ * modes authenticate the server certificate. Managed engines such as RDS
+ * present certificates signed by their own CA, which is absent from the system
+ * trust store, so verifying by default would break them.
+ */
+export function resolveMysqlSsl(
+  connection: DatabaseConnection,
+  iamAuth = false
+): Record<string, unknown> | undefined {
+  const sslMode = (
+    readConnectionProp(connection, 'ssl.mode', 'sslMode', 'sslmode', 'useSSL', 'ssl') ?? ''
+  ).toLowerCase();
+
+  if (MYSQL_DISABLE_MODES.includes(sslMode)) {
+    return undefined;
+  }
+
+  if (!MYSQL_REQUIRE_MODES.includes(sslMode) && !iamAuth) {
+    return undefined;
+  }
+
+  const material = buildSslMaterial(
+    readConnectionProp(connection, 'ssl.ca', 'sslCA', 'sslrootcert'),
+    readConnectionProp(connection, 'ssl.cert', 'sslCert', 'sslcert'),
+    readConnectionProp(connection, 'ssl.key', 'sslKey', 'sslkey')
+  );
+
+  const hasCa = typeof material.ca === 'string' && material.ca.length > 0;
+
+  return {
+    ...material,
+    rejectUnauthorized: MYSQL_VERIFY_MODES.includes(sslMode) || hasCa,
+  };
+}

--- a/src/config-parser.ts
+++ b/src/config-parser.ts
@@ -5,6 +5,7 @@ import { parseString } from 'xml2js';
 import { promisify } from 'util';
 import crypto from 'crypto';
 import { DatabaseConnection, WorkspaceConfig } from './types.js';
+import { resolveDriverDialect, parseJdbcUrl } from './utils.js';
 
 const parseXML = promisify(parseString);
 
@@ -181,10 +182,17 @@ export class WorkspaceConfigParser {
     for (const [connectionId, connData] of Object.entries(data.connections)) {
       const conn = connData as any;
 
+      const rawDriver = conn.driver || '';
+      const url = conn.configuration?.url || '';
+
       const connection: DatabaseConnection = {
         id: connectionId,
         name: conn.name || connectionId,
-        driver: conn.driver || conn.provider || '',
+        // Custom drivers can carry an opaque id (e.g. a UUID), which no native
+        // routing would match. Resolve it to a dialect via provider/URL.
+        driver: resolveDriverDialect(rawDriver, conn.provider, url) || conn.provider || '',
+        driverId: rawDriver || undefined,
+        provider: conn.provider || undefined,
         url: '',
         folder: conn.folder || '',
         description: conn.description || '',
@@ -194,7 +202,7 @@ export class WorkspaceConfigParser {
       // Extract properties from the new format
       if (conn.configuration) {
         const config = conn.configuration;
-        connection.properties = {
+        const props: Record<string, string> = {
           url: config.url || '',
           user: config.user || '',
           host: config.host || '',
@@ -204,11 +212,28 @@ export class WorkspaceConfigParser {
           ...config,
         };
 
+        connection.properties = props;
         connection.url = config.url || '';
         connection.user = config.user || '';
         connection.host = config.host || config.server || '';
         connection.port = config.port ? parseInt(String(config.port)) : undefined;
         connection.database = config.database || '';
+
+        // Backfill anything the config omits but the JDBC URL carries. Custom
+        // drivers sometimes record only the URL.
+        const fromUrl = parseJdbcUrl(connection.url);
+        if (!connection.host && fromUrl.host) {
+          connection.host = fromUrl.host;
+          props.host = fromUrl.host;
+        }
+        if (!connection.port && fromUrl.port) {
+          connection.port = fromUrl.port;
+          props.port = String(fromUrl.port);
+        }
+        if (!connection.database && fromUrl.database) {
+          connection.database = fromUrl.database;
+          props.database = fromUrl.database;
+        }
       }
 
       connections.push(connection);
@@ -236,19 +261,9 @@ export class WorkspaceConfigParser {
       : [xmlData.connections.connection];
 
     for (const conn of connectionArray) {
-      const connection: DatabaseConnection = {
-        id: conn.$.id || '',
-        name: conn.$.name || '',
-        driver: conn.$.driver || '',
-        url: '',
-        folder: conn.$.folder || '',
-        description: conn.$.description || '',
-        readonly: conn.$.readonly === 'true',
-      };
-
-      // Extract properties
+      // Collect properties first: the JDBC URL feeds driver dialect resolution.
+      const properties: Record<string, string> = {};
       if (conn.property) {
-        const properties: Record<string, string> = {};
         const propArray = Array.isArray(conn.property) ? conn.property : [conn.property];
 
         for (const prop of propArray) {
@@ -256,13 +271,44 @@ export class WorkspaceConfigParser {
             properties[prop.$.name] = prop.$.value;
           }
         }
+      }
 
+      const rawDriver = conn.$.driver || '';
+      const provider = conn.$.provider || '';
+
+      const connection: DatabaseConnection = {
+        id: conn.$.id || '',
+        name: conn.$.name || '',
+        driver: resolveDriverDialect(rawDriver, provider, properties.url) || provider,
+        driverId: rawDriver || undefined,
+        provider: provider || undefined,
+        url: '',
+        folder: conn.$.folder || '',
+        description: conn.$.description || '',
+        readonly: conn.$.readonly === 'true',
+      };
+
+      if (conn.property) {
         connection.properties = properties;
         connection.url = properties.url || '';
         connection.user = properties.user || '';
         connection.host = properties.host || '';
         connection.port = properties.port ? parseInt(properties.port) : undefined;
         connection.database = properties.database || '';
+
+        const fromUrl = parseJdbcUrl(connection.url);
+        if (!connection.host && fromUrl.host) {
+          connection.host = fromUrl.host;
+          connection.properties.host = fromUrl.host;
+        }
+        if (!connection.port && fromUrl.port) {
+          connection.port = fromUrl.port;
+          connection.properties.port = String(fromUrl.port);
+        }
+        if (!connection.database && fromUrl.database) {
+          connection.database = fromUrl.database;
+          connection.properties.database = fromUrl.database;
+        }
       }
 
       connections.push(connection);

--- a/src/index.ts
+++ b/src/index.ts
@@ -942,6 +942,11 @@ class OmniSQLMCPServer {
       id: conn.id,
       name: conn.name,
       driver: conn.driver,
+      // Only interesting when the configured id needed resolving to a dialect,
+      // as custom drivers with an opaque id do.
+      ...(conn.driverId && conn.driverId !== conn.driver
+        ? { driverId: conn.driverId, provider: conn.provider }
+        : {}),
       host: conn.host,
       database: conn.database,
       folder: conn.folder,

--- a/src/pools/connection-pool.ts
+++ b/src/pools/connection-pool.ts
@@ -2,6 +2,8 @@ import { Pool as PgPool } from 'pg';
 import mysql, { Pool as MySqlPool } from 'mysql2/promise';
 import sql, { ConnectionPool as MssqlPool } from 'mssql';
 import { DatabaseConnection, PoolConfig, PoolStats } from '../types.js';
+import { isIamAuthConnection, resolveIamCredentials } from '../auth/iam-auth.js';
+import { resolvePostgresSsl, resolveMysqlSsl } from '../auth/ssl.js';
 
 const DEFAULT_POOL_CONFIG: PoolConfig = {
   min: 2,
@@ -102,19 +104,37 @@ export class ConnectionPoolManager {
   private async createPostgresPool(connection: DatabaseConnection): Promise<PoolEntry> {
     this.log(`Creating PostgreSQL pool for ${connection.name}`);
 
-    const sslConfig = this.getPostgresSslConfig(connection);
+    const iamAuth = isIamAuthConnection(connection);
+    const resolvedSsl = resolvePostgresSsl(connection, iamAuth, this.debug);
+    // When a connection says nothing about TLS the resolver defers to the
+    // driver, but pooled connections have always opted into opportunistic
+    // unverified TLS here. Keep that so servers demanding TLS keep working.
+    const ssl = resolvedSsl === undefined ? { rejectUnauthorized: false } : resolvedSsl;
+
+    let user = connection.user;
+    let password: string | (() => Promise<string>) | undefined = connection.properties?.password;
+
+    if (iamAuth) {
+      // Resolve the username once, but hand pg a password *function*: it is
+      // invoked per physical connection, so a pool outliving the token's
+      // 15-minute lifetime still authenticates with a fresh one.
+      const creds = await resolveIamCredentials(connection, 5432, { debug: this.debug });
+      user = creds.user;
+      password = async () =>
+        (await resolveIamCredentials(connection, 5432, { debug: this.debug })).password;
+    }
 
     const pool = new PgPool({
       host: connection.host,
       port: connection.port || 5432,
       database: connection.database,
-      user: connection.user,
-      password: connection.properties?.password,
+      user,
+      password,
       min: this.config.min,
       max: this.config.max,
       idleTimeoutMillis: this.config.idleTimeoutMs,
       connectionTimeoutMillis: this.config.acquireTimeoutMs,
-      ...sslConfig,
+      ssl,
     });
 
     const entry: PoolEntry = {
@@ -128,53 +148,39 @@ export class ConnectionPoolManager {
     return entry;
   }
 
-  private getPostgresSslConfig(connection: DatabaseConnection): object {
-    const props = connection.properties || {};
-    // The workspace JSON config format stores driver properties under a nested `properties` key,
-    // and SSL handler config under `handlers.postgre_ssl`. Check all locations.
-    const nestedProps = (props.properties as unknown as Record<string, unknown>) || {};
-    const sslHandler = (props.handlers as unknown as Record<string, unknown> | undefined)?.[
-      'postgre_ssl'
-    ] as Record<string, unknown> | undefined;
-    const sslMode =
-      props.sslmode ||
-      props.ssl ||
-      nestedProps['sslmode'] ||
-      nestedProps['ssl'] ||
-      (sslHandler?.enabled
-        ? (sslHandler?.properties as Record<string, unknown>)?.['sslMode'] || 'require'
-        : undefined);
+  private async createMysqlPool(connection: DatabaseConnection): Promise<PoolEntry> {
+    this.log(`Creating MySQL pool for ${connection.name}`);
 
-    if (sslMode === 'disable' || sslMode === 'false') {
-      return { ssl: false };
-    }
+    const iamAuth = isIamAuthConnection(connection);
+    const ssl = resolveMysqlSsl(connection, iamAuth);
 
-    if (
-      sslMode === 'require' ||
-      sslMode === 'true' ||
-      sslMode === 'verify-ca' ||
-      sslMode === 'verify-full'
-    ) {
-      return {
-        ssl: {
-          rejectUnauthorized: sslMode === 'verify-full',
+    let user = connection.user;
+    let password = connection.properties?.password;
+    let authPlugins: mysql.PoolOptions['authPlugins'];
+
+    if (iamAuth) {
+      const creds = await resolveIamCredentials(connection, 3306, { debug: this.debug });
+      user = creds.user;
+      password = creds.password;
+      // RDS switches IAM users to mysql_clear_password. mysql2 invokes this
+      // factory per physical connection, so mint a fresh token there and a
+      // pool outliving the token's 15-minute lifetime keeps working.
+      authPlugins = {
+        mysql_clear_password: () => async () => {
+          const fresh = await resolveIamCredentials(connection, 3306, { debug: this.debug });
+          return Buffer.from(`${fresh.password}\0`);
         },
       };
     }
-
-    // Default: try SSL but don't require it
-    return { ssl: { rejectUnauthorized: false } };
-  }
-
-  private async createMysqlPool(connection: DatabaseConnection): Promise<PoolEntry> {
-    this.log(`Creating MySQL pool for ${connection.name}`);
 
     const pool = mysql.createPool({
       host: connection.host,
       port: connection.port || 3306,
       database: connection.database,
-      user: connection.user,
-      password: connection.properties?.password,
+      user,
+      password,
+      ssl,
+      authPlugins,
       connectionLimit: this.config.max,
       waitForConnections: true,
       queueLimit: 0,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,16 @@
 export interface DatabaseConnection {
   id: string;
   name: string;
+  /**
+   * Driver id normalized to a dialect the native routing can dispatch on.
+   * Custom drivers may use an opaque id (e.g. a UUID), in which case this is
+   * resolved from the connection's `provider` or JDBC URL sub-protocol.
+   */
   driver: string;
+  /** Driver id exactly as configured in the workspace, for display and errors. */
+  driverId?: string;
+  /** Workspace `provider` id, e.g. "postgresql" or "mysql". */
+  provider?: string;
   url: string;
   user?: string;
   host?: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,6 +10,172 @@ export function findCliExecutable(): string {
 }
 
 /**
+ * Dialect tokens that the rest of the codebase pattern-matches on to pick a
+ * native driver. A driver id containing any of these is already routable.
+ */
+const DIALECT_TOKENS = [
+  'postgres',
+  'postgresql',
+  'cockroach',
+  'timescale',
+  'redshift',
+  'yugabyte',
+  'alloydb',
+  'supabase',
+  'neon',
+  'citus',
+  'mysql',
+  'mariadb',
+  'mssql',
+  'sqlserver',
+  'microsoft',
+  'sqlite',
+  'oracle',
+  'db2',
+  'hana',
+  'mongodb',
+  'redis',
+];
+
+/**
+ * Map a workspace `provider` id onto a dialect token.
+ *
+ * Providers are stable across custom drivers: a hand-rolled driver keeps
+ * `provider: "postgresql"` even when its driver id is an opaque UUID.
+ */
+const PROVIDER_DIALECTS: Record<string, string> = {
+  postgresql: 'postgresql',
+  postgres: 'postgresql',
+  cockroach: 'cockroachdb',
+  timescale: 'timescaledb',
+  redshift: 'redshift',
+  yugabyte: 'yugabytedb',
+  greenplum: 'postgresql',
+  mysql: 'mysql',
+  mariadb: 'mariadb',
+  mssql: 'mssql',
+  sqlserver: 'mssql',
+  sqlite: 'sqlite',
+  oracle: 'oracle',
+  db2: 'db2',
+};
+
+/**
+ * True when a driver id already carries a dialect the native routing understands.
+ */
+export function isRoutableDriverId(driver: string): boolean {
+  const d = driver.toLowerCase();
+  return DIALECT_TOKENS.some((token) => d.includes(token));
+}
+
+/**
+ * Extract the dialect from a JDBC URL, tolerating wrapper sub-protocols.
+ *
+ * Custom drivers commonly layer a wrapper in front of the engine sub-protocol,
+ * e.g. the AWS Advanced JDBC Wrapper's `jdbc:aws-wrapper:postgresql://host/db`.
+ * Scan every colon-delimited segment and return the first recognised dialect,
+ * so unknown wrapper names never mask the engine behind them.
+ */
+export function dialectFromJdbcUrl(url: string): string | null {
+  if (!url) {
+    return null;
+  }
+
+  const withoutAuthority = url.split('://')[0].toLowerCase();
+  const segments = withoutAuthority.split(':').filter((s) => s && s !== 'jdbc');
+
+  for (const segment of segments) {
+    if (PROVIDER_DIALECTS[segment]) {
+      return PROVIDER_DIALECTS[segment];
+    }
+  }
+
+  // Fall back to a looser match so e.g. `mysql8` or `postgresql-42` still resolve.
+  for (const segment of segments) {
+    const token = DIALECT_TOKENS.find((t) => segment.includes(t));
+    if (token) {
+      return token;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Resolve a driver id that the native routing can dispatch on.
+ *
+ * Stock workspace drivers ("postgres-jdbc", "mysql8") already contain their
+ * dialect and are returned untouched. Custom drivers may use an opaque id -
+ * a UUID, say - in which case fall back to the connection's `provider` and
+ * finally to the JDBC URL's sub-protocol.
+ *
+ * Returns the original id when nothing resolves, so error messages still name
+ * the driver the user actually configured.
+ */
+export function resolveDriverDialect(
+  driver: string | undefined,
+  provider?: string,
+  url?: string
+): string {
+  const rawDriver = driver ?? '';
+
+  if (rawDriver && isRoutableDriverId(rawDriver)) {
+    return rawDriver;
+  }
+
+  const providerKey = (provider ?? '').toLowerCase();
+  if (PROVIDER_DIALECTS[providerKey]) {
+    return PROVIDER_DIALECTS[providerKey];
+  }
+  if (providerKey && isRoutableDriverId(providerKey)) {
+    return providerKey;
+  }
+
+  const fromUrl = dialectFromJdbcUrl(url ?? '');
+  if (fromUrl) {
+    return fromUrl;
+  }
+
+  return rawDriver || providerKey;
+}
+
+/**
+ * Parse host, port and database out of a JDBC URL.
+ *
+ * Used only to backfill fields a connection config omits; wrapper
+ * sub-protocols and query strings are both tolerated.
+ */
+export function parseJdbcUrl(url: string): { host?: string; port?: number; database?: string } {
+  if (!url) {
+    return {};
+  }
+
+  const authorityIdx = url.indexOf('://');
+  if (authorityIdx === -1) {
+    return {};
+  }
+
+  let remainder = url.slice(authorityIdx + 3);
+  // Strip query string / JDBC property suffixes before splitting on '/'.
+  remainder = remainder.split('?')[0].split(';')[0];
+
+  const slashIdx = remainder.indexOf('/');
+  const authority = slashIdx === -1 ? remainder : remainder.slice(0, slashIdx);
+  const database = slashIdx === -1 ? '' : remainder.slice(slashIdx + 1);
+
+  // Only the final colon separates the port, so IPv6 literals survive.
+  const portMatch = authority.match(/^(.*):(\d+)$/);
+  const host = portMatch ? portMatch[1] : authority;
+  const port = portMatch ? parseInt(portMatch[2], 10) : undefined;
+
+  const result: { host?: string; port?: number; database?: string } = {};
+  if (host) result.host = host;
+  if (port !== undefined && !Number.isNaN(port)) result.port = port;
+  if (database) result.database = database;
+  return result;
+}
+
+/**
  * Validate SQL query for basic safety
  */
 export function validateQuery(query: string): string | null {

--- a/src/workspace-client.ts
+++ b/src/workspace-client.ts
@@ -22,6 +22,8 @@ import {
   buildSchemaQuery,
   buildListTablesQuery,
 } from './utils.js';
+import { isIamAuthConnection, resolveIamCredentials } from './auth/iam-auth.js';
+import { resolvePostgresSsl, resolveMysqlSsl } from './auth/ssl.js';
 
 export class WorkspaceClient {
   private executablePath: string;
@@ -202,13 +204,22 @@ export class WorkspaceClient {
         const nativeDrivers =
           'PostgreSQL (+ CockroachDB, TimescaleDB, Redshift, YugabyteDB, Supabase, Neon, Citus, AlloyDB), MySQL/MariaDB, SQL Server (MSSQL), SQLite';
         const cliMsg = cliError instanceof Error ? cliError.message : String(cliError);
+        // Custom drivers can carry an opaque id; surfacing it alongside the
+        // provider makes an unresolved dialect obvious rather than mysterious.
+        const identity =
+          connection.driverId && connection.driverId !== driverName
+            ? `"${driverName}" (driver id "${connection.driverId}"${
+                connection.provider ? `, provider "${connection.provider}"` : ''
+              })`
+            : `"${driverName}"`;
         throw new Error(
-          `Database driver "${driverName}" is not natively supported. ` +
+          `Database driver ${identity} is not natively supported. ` +
             `Natively supported drivers: ${nativeDrivers}. ` +
             `CLI fallback also failed: ${cliMsg}. ` +
-            `To use "${driverName}", consider connecting through a supported driver ` +
-            `(e.g. via an ODBC/JDBC bridge) or ensure a compatible DB client CLI is installed and ` +
-            `the connection is configured in your workspace.`
+            `If this is a custom driver wrapping a supported engine, set its connection ` +
+            `"provider" (or a JDBC URL such as jdbc:postgresql://...) so the engine can be ` +
+            `detected; otherwise connect through a supported driver or ensure a compatible ` +
+            `DB client CLI is installed.`
         );
       }
     }
@@ -333,73 +344,25 @@ export class WorkspaceClient {
       connection.port ||
       (connection.properties?.port ? parseInt(connection.properties.port) : 5432);
     const database = connection.database || connection.properties?.database || 'postgres';
-    const user = connection.user || connection.properties?.user || process.env.PGUSER || 'postgres';
-    const password = connection.properties?.password || process.env.PGPASSWORD;
 
-    // SSL handling
-    // The workspace JSON config format stores driver properties under a nested `properties` key,
-    // and SSL handler config under `handlers.postgre_ssl`. Check all locations.
-    const nestedProps =
-      (connection.properties?.['properties'] as unknown as Record<string, unknown>) || {};
-    const sslHandler = (
-      connection.properties?.['handlers'] as unknown as Record<string, unknown> | undefined
-    )?.['postgre_ssl'] as Record<string, unknown> | undefined;
-    const sslModeRaw =
-      connection.properties?.['ssl.mode'] ||
-      connection.properties?.['sslmode'] ||
-      connection.properties?.['ssl'] ||
-      nestedProps['sslmode'] ||
-      nestedProps['ssl'] ||
-      (sslHandler?.enabled
-        ? (sslHandler?.properties as Record<string, unknown>)?.['sslMode'] || 'require'
-        : undefined);
-    const sslMode = String(sslModeRaw ?? '').toLowerCase();
-    const sslRootCert =
-      connection.properties?.['sslrootcert'] ||
-      connection.properties?.['ssl.root.cert'] ||
-      connection.properties?.['sslRootCert'];
-    const sslCert =
-      connection.properties?.['sslcert'] ||
-      connection.properties?.['ssl.cert'] ||
-      connection.properties?.['sslCert'];
-    const sslKey =
-      connection.properties?.['sslkey'] ||
-      connection.properties?.['ssl.key'] ||
-      connection.properties?.['sslKey'];
+    // IAM-authenticated connections store no credential, so mint a short-lived
+    // token and authenticate with that. This also resolves the username, which
+    // such connections frequently omit.
+    const iamAuth = isIamAuthConnection(connection);
+    const iamCreds = iamAuth
+      ? await resolveIamCredentials(connection, 5432, { debug: this.debug })
+      : undefined;
 
-    let ssl: any = undefined;
-    const requireSsl = ['require', 'verify-ca', 'verify-full', 'true', '1'].includes(sslMode);
-    const verifyModes = ['verify-ca', 'verify-full'];
-    const disableSsl = ['disable', 'false', '0'].includes(sslMode);
-    if (requireSsl) {
-      const sslObj: any = {};
-      try {
-        if (sslRootCert && fs.existsSync(String(sslRootCert)))
-          sslObj.ca = fs.readFileSync(String(sslRootCert)).toString();
-        if (sslCert && fs.existsSync(String(sslCert)))
-          sslObj.cert = fs.readFileSync(String(sslCert)).toString();
-        if (sslKey && fs.existsSync(String(sslKey)))
-          sslObj.key = fs.readFileSync(String(sslKey)).toString();
-      } catch {
-        // ignore errors, we'll set a reasonable default below
-      }
-      const hasCa = typeof sslObj.ca === 'string' && sslObj.ca.length > 0;
-      if (verifyModes.includes(sslMode)) {
-        // Enforce certificate verification. If no custom CA is provided, fallback to system trust store.
-        sslObj.rejectUnauthorized = true;
-        if (this.debug && !hasCa) {
-          console.warn(
-            'sslMode set to verify-ca/verify-full but no sslrootcert provided; using system CA store'
-          );
-        }
-      } else {
-        // "require" mode: encrypt without verification
-        sslObj.rejectUnauthorized = false;
-      }
-      ssl = sslObj;
-    } else if (disableSsl) {
-      ssl = false;
-    }
+    const user =
+      iamCreds?.user ||
+      connection.user ||
+      connection.properties?.user ||
+      process.env.PGUSER ||
+      'postgres';
+    const password =
+      iamCreds?.password || connection.properties?.password || process.env.PGPASSWORD;
+
+    const ssl = resolvePostgresSsl(connection, iamAuth, this.debug);
 
     const client = new Client({ host, port, database, user, password, ssl });
     try {
@@ -500,60 +463,28 @@ export class WorkspaceClient {
       connection.port ||
       (connection.properties?.port ? parseInt(connection.properties.port) : 3306);
     const database = connection.database || connection.properties?.database;
-    const user = connection.user || connection.properties?.user || process.env.MYSQL_USER || 'root';
+
+    // IAM-authenticated connections store no credential, so mint a short-lived
+    // token and authenticate with that. mysql2 answers RDS's auth-plugin switch
+    // with mysql_clear_password out of the box, safe over the TLS we force below.
+    const iamAuth = isIamAuthConnection(connection);
+    const iamCreds = iamAuth
+      ? await resolveIamCredentials(connection, 3306, { debug: this.debug })
+      : undefined;
+
+    const user =
+      iamCreds?.user ||
+      connection.user ||
+      connection.properties?.user ||
+      process.env.MYSQL_USER ||
+      'root';
     const password =
-      connection.properties?.password || process.env.MYSQL_PWD || process.env.MYSQL_PASSWORD;
+      iamCreds?.password ||
+      connection.properties?.password ||
+      process.env.MYSQL_PWD ||
+      process.env.MYSQL_PASSWORD;
 
-    // SSL handling (best-effort; varies across workspace driver configs)
-    const sslModeRaw =
-      connection.properties?.['ssl.mode'] ||
-      connection.properties?.['sslMode'] ||
-      connection.properties?.['sslmode'] ||
-      connection.properties?.['useSSL'] ||
-      connection.properties?.['ssl'];
-    const sslMode = String(sslModeRaw ?? '').toLowerCase();
-    const sslCa =
-      connection.properties?.['ssl.ca'] ||
-      connection.properties?.['sslCA'] ||
-      connection.properties?.['sslrootcert'];
-    const sslCert =
-      connection.properties?.['ssl.cert'] ||
-      connection.properties?.['sslCert'] ||
-      connection.properties?.['sslcert'];
-    const sslKey =
-      connection.properties?.['ssl.key'] ||
-      connection.properties?.['sslKey'] ||
-      connection.properties?.['sslkey'];
-
-    let ssl: any = undefined;
-    const requireSsl = [
-      'require',
-      'verify-ca',
-      'verify-full',
-      'true',
-      '1',
-      'preferred',
-      'enabled',
-      'yes',
-    ].includes(sslMode);
-    const disableSsl = ['disable', 'false', '0', 'none', 'off', 'no'].includes(sslMode);
-    if (requireSsl) {
-      const sslObj: any = {};
-      try {
-        if (sslCa && fs.existsSync(String(sslCa)))
-          sslObj.ca = fs.readFileSync(String(sslCa)).toString();
-        if (sslCert && fs.existsSync(String(sslCert)))
-          sslObj.cert = fs.readFileSync(String(sslCert)).toString();
-        if (sslKey && fs.existsSync(String(sslKey)))
-          sslObj.key = fs.readFileSync(String(sslKey)).toString();
-      } catch {
-        // ignore and let mysql2 use defaults
-      }
-      // For MySQL, verification behavior depends on the TLS layer. If CA is provided, mysql2 will verify.
-      ssl = sslObj;
-    } else if (disableSsl) {
-      ssl = undefined;
-    }
+    const ssl = resolveMysqlSsl(connection, iamAuth);
 
     const connectTimeout = Math.max(1000, this.timeout);
     const connectionConfig: mysql.ConnectionOptions = {

--- a/tests/driver-resolution.test.ts
+++ b/tests/driver-resolution.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolveDriverDialect,
+  dialectFromJdbcUrl,
+  parseJdbcUrl,
+  isRoutableDriverId,
+} from '../src/utils.js';
+
+describe('isRoutableDriverId', () => {
+  it('accepts stock driver ids that name their engine', () => {
+    expect(isRoutableDriverId('postgres-jdbc')).toBe(true);
+    expect(isRoutableDriverId('mysql8')).toBe(true);
+    expect(isRoutableDriverId('sqlite_jdbc')).toBe(true);
+  });
+
+  it('rejects opaque ids used by custom drivers', () => {
+    expect(isRoutableDriverId('35379A2C-3AE9-529E-B72B-244C753C055B')).toBe(false);
+    expect(isRoutableDriverId('')).toBe(false);
+  });
+});
+
+describe('dialectFromJdbcUrl', () => {
+  it('reads the engine from a plain JDBC URL', () => {
+    expect(dialectFromJdbcUrl('jdbc:postgresql://db.example.com:5432/app')).toBe('postgresql');
+    expect(dialectFromJdbcUrl('jdbc:mysql://db.example.com:3306/app')).toBe('mysql');
+  });
+
+  it('sees past a wrapper sub-protocol to the real engine', () => {
+    expect(dialectFromJdbcUrl('jdbc:aws-wrapper:postgresql://db.example.com:5432/app')).toBe(
+      'postgresql'
+    );
+    expect(dialectFromJdbcUrl('jdbc:aws-wrapper:mysql://db.example.com:3306/')).toBe('mysql');
+  });
+
+  it('returns null when no engine can be identified', () => {
+    expect(dialectFromJdbcUrl('jdbc:acme-proprietary://host/db')).toBeNull();
+    expect(dialectFromJdbcUrl('')).toBeNull();
+  });
+});
+
+describe('resolveDriverDialect', () => {
+  it('leaves stock driver ids untouched', () => {
+    expect(resolveDriverDialect('postgres-jdbc', 'postgresql', 'jdbc:postgresql://h/d')).toBe(
+      'postgres-jdbc'
+    );
+    expect(resolveDriverDialect('mysql8', 'mysql', '')).toBe('mysql8');
+  });
+
+  it('falls back to the provider for an opaque custom driver id', () => {
+    expect(
+      resolveDriverDialect(
+        '35379A2C-3AE9-529E-B72B-244C753C055B',
+        'postgresql',
+        'jdbc:aws-wrapper:postgresql://h:5432/postgres'
+      )
+    ).toBe('postgresql');
+
+    expect(
+      resolveDriverDialect(
+        '8C75BE41-09DC-5868-B24A-9224F6FC750F',
+        'mysql',
+        'jdbc:aws-wrapper:mysql://h:3306/'
+      )
+    ).toBe('mysql');
+  });
+
+  it('falls back to the JDBC URL when the provider is also unhelpful', () => {
+    expect(
+      resolveDriverDialect('some-uuid', 'custom-provider', 'jdbc:aws-wrapper:postgresql://h/d')
+    ).toBe('postgresql');
+  });
+
+  it('returns the raw id when nothing resolves, so errors can name it', () => {
+    expect(resolveDriverDialect('acme-driver', 'acme', 'jdbc:acme://h/d')).toBe('acme-driver');
+  });
+
+  it('routes resolved dialects the way the native dispatch expects', () => {
+    // The dispatch in workspace-client/connection-pool substring-matches these.
+    const pg = resolveDriverDialect('UUID-1', 'postgresql', '');
+    const my = resolveDriverDialect('UUID-2', 'mysql', '');
+    expect(pg.toLowerCase().includes('postgres')).toBe(true);
+    expect(my.toLowerCase().includes('mysql')).toBe(true);
+  });
+});
+
+describe('parseJdbcUrl', () => {
+  it('pulls host, port and database out of a wrapper URL', () => {
+    expect(
+      parseJdbcUrl(
+        'jdbc:aws-wrapper:postgresql://shared-int.cluster-x.us-east-1.rds.amazonaws.com:5432/postgres'
+      )
+    ).toEqual({
+      host: 'shared-int.cluster-x.us-east-1.rds.amazonaws.com',
+      port: 5432,
+      database: 'postgres',
+    });
+  });
+
+  it('omits an empty database segment', () => {
+    expect(
+      parseJdbcUrl('jdbc:aws-wrapper:mysql://db.x.us-gov-east-1.rds.amazonaws.com:3306/')
+    ).toEqual({
+      host: 'db.x.us-gov-east-1.rds.amazonaws.com',
+      port: 3306,
+    });
+  });
+
+  it('tolerates a missing port and trailing properties', () => {
+    expect(parseJdbcUrl('jdbc:postgresql://db.example.com/app?sslmode=require')).toEqual({
+      host: 'db.example.com',
+      database: 'app',
+    });
+  });
+
+  it('returns nothing for a URL with no authority', () => {
+    expect(parseJdbcUrl('jdbc:sqlite:/tmp/local.db')).toEqual({});
+    expect(parseJdbcUrl('')).toEqual({});
+  });
+});

--- a/tests/iam-auth.test.ts
+++ b/tests/iam-auth.test.ts
@@ -1,0 +1,337 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  isIamAuthConnection,
+  regionFromRdsHost,
+  dbUserFromCallerArn,
+  resolveIamUsername,
+  resolveIamTarget,
+  getIamAuthToken,
+  resolveIamCredentials,
+  clearIamAuthCache,
+  AwsCommandRunner,
+} from '../src/auth/iam-auth.js';
+import { DatabaseConnection } from '../src/types.js';
+
+/**
+ * A connection shaped like the ones an AWS Advanced JDBC Wrapper driver writes:
+ * an opaque driver id, engine properties nested under `properties`, and no
+ * stored password or username.
+ */
+function iamConnection(overrides: Partial<DatabaseConnection> = {}): DatabaseConnection {
+  return {
+    id: '35379A2C-3AE9-529E-B72B-244C753C055B-custom-3fea10ef',
+    name: 'shared-int-postgres (example-int-db)',
+    driver: 'postgresql',
+    driverId: '35379A2C-3AE9-529E-B72B-244C753C055B',
+    provider: 'postgresql',
+    url: 'jdbc:aws-wrapper:postgresql://shared-int.cluster-x.us-east-1.rds.amazonaws.com:5432/postgres',
+    host: 'shared-int.cluster-x.us-east-1.rds.amazonaws.com',
+    port: 5432,
+    database: 'postgres',
+    properties: {
+      host: 'shared-int.cluster-x.us-east-1.rds.amazonaws.com',
+      port: '5432',
+      database: 'postgres',
+      'auth-model': 'native',
+      properties: {
+        wrapperPlugins: 'iam',
+        awsProfile: 'example-int-db',
+        iamRegion: 'us-east-1',
+        allowAwsLoginSession: 'true',
+        sslmode: 'require',
+      },
+    } as unknown as Record<string, string>,
+    ...overrides,
+  };
+}
+
+/** Records the AWS CLI invocations a call makes and returns canned stdout. */
+function stubRunner(responses: Record<string, string>): {
+  runner: AwsCommandRunner;
+  calls: string[][];
+} {
+  const calls: string[][] = [];
+  const runner: AwsCommandRunner = async (args) => {
+    calls.push(args);
+    const key = `${args[0]} ${args[1]}`;
+    if (!(key in responses)) {
+      throw new Error(`unexpected AWS call: ${key}`);
+    }
+    return responses[key];
+  };
+  return { runner, calls };
+}
+
+describe('isIamAuthConnection', () => {
+  it('detects the aws-wrapper iam plugin nested in driver properties', () => {
+    expect(isIamAuthConnection(iamConnection())).toBe(true);
+  });
+
+  it('detects an iam auth model', () => {
+    const conn = iamConnection({
+      properties: { 'auth-model': 'postgres_aws_iam' } as unknown as Record<string, string>,
+    });
+    expect(isIamAuthConnection(conn)).toBe(true);
+  });
+
+  it('ignores a wrapper used without the iam plugin', () => {
+    const conn = iamConnection({
+      properties: {
+        properties: { wrapperPlugins: 'failover,efm' },
+      } as unknown as Record<string, string>,
+    });
+    expect(isIamAuthConnection(conn)).toBe(false);
+  });
+
+  it('leaves ordinary password connections alone', () => {
+    const conn: DatabaseConnection = {
+      id: 'postgres-jdbc-1',
+      name: 'local',
+      driver: 'postgres-jdbc',
+      url: 'jdbc:postgresql://localhost:5432/app',
+      properties: { host: 'localhost', user: 'app', password: 'placeholder-not-a-secret' },
+    };
+    expect(isIamAuthConnection(conn)).toBe(false);
+  });
+});
+
+describe('regionFromRdsHost', () => {
+  it('reads commercial and GovCloud regions from RDS endpoints', () => {
+    expect(regionFromRdsHost('db.cluster-abc.us-east-1.rds.amazonaws.com')).toBe('us-east-1');
+    expect(regionFromRdsHost('db.abc.us-gov-east-1.rds.amazonaws.com')).toBe('us-gov-east-1');
+    expect(regionFromRdsHost('db.abc.ap-southeast-2.rds.amazonaws.com')).toBe('ap-southeast-2');
+  });
+
+  it('returns undefined for non-RDS hosts', () => {
+    expect(regionFromRdsHost('localhost')).toBeUndefined();
+    expect(regionFromRdsHost('db.internal.example.com')).toBeUndefined();
+  });
+});
+
+describe('dbUserFromCallerArn', () => {
+  it('takes the username from an assumed SSO role session', () => {
+    expect(
+      dbUserFromCallerArn(
+        'arn:aws:sts::123456789012:assumed-role/AWSReservedSSO_Admin_abc/devuser@example.com'
+      )
+    ).toBe('devuser');
+  });
+
+  it('strips the profile prefix off a per-developer role name', () => {
+    // Role-chained profiles produce an SDK-generated session name, so the role
+    // name is the only thing identifying the developer.
+    expect(
+      dbUserFromCallerArn(
+        'arn:aws:sts::123456789012:assumed-role/example-int-db-devuser/botocore-session-1785446405',
+        'example-int-db'
+      )
+    ).toBe('devuser');
+
+    expect(
+      dbUserFromCallerArn(
+        'arn:aws-us-gov:sts::123456789012:assumed-role/example-gov-db-devuser/botocore-session-1785446428',
+        'example-gov-db'
+      )
+    ).toBe('devuser');
+  });
+
+  it('never mistakes a generated session name for a username', () => {
+    expect(
+      dbUserFromCallerArn(
+        'arn:aws:sts::123:assumed-role/some-unrelated-role/botocore-session-1785446405'
+      )
+    ).toBeUndefined();
+  });
+
+  it('handles an assumed role session with no email suffix', () => {
+    expect(dbUserFromCallerArn('arn:aws:sts::123:assumed-role/some-db-role/devuser')).toBe(
+      'devuser'
+    );
+  });
+
+  it('handles a plain IAM user arn', () => {
+    expect(dbUserFromCallerArn('arn:aws:iam::123456789012:user/devuser')).toBe('devuser');
+  });
+
+  it('returns undefined for a root or unrecognised arn', () => {
+    expect(dbUserFromCallerArn('arn:aws:iam::123456789012:root')).toBeUndefined();
+  });
+});
+
+describe('resolveIamUsername', () => {
+  beforeEach(() => {
+    clearIamAuthCache();
+    delete process.env.AWS_PROFILE;
+  });
+
+  it('prefers a username recorded on the connection', async () => {
+    const { runner, calls } = stubRunner({});
+    const user = await resolveIamUsername(iamConnection({ user: 'explicit_user' }), { runner });
+
+    expect(user).toBe('explicit_user');
+    expect(calls).toHaveLength(0);
+  });
+
+  it('derives the username from the caller identity when absent', async () => {
+    const { runner, calls } = stubRunner({
+      'sts get-caller-identity': JSON.stringify({
+        Arn: 'arn:aws:sts::123:assumed-role/AWSReservedSSO_Admin_x/devuser@example.com',
+      }),
+    });
+
+    expect(await resolveIamUsername(iamConnection(), { runner })).toBe('devuser');
+    // Derived against the connection's own profile, not the ambient default.
+    expect(calls[0]).toContain('--profile');
+    expect(calls[0]).toContain('example-int-db');
+  });
+
+  it('caches the derived username per profile', async () => {
+    const { runner, calls } = stubRunner({
+      'sts get-caller-identity': JSON.stringify({
+        Arn: 'arn:aws:sts::123:assumed-role/role/devuser@example.com',
+      }),
+    });
+
+    await resolveIamUsername(iamConnection(), { runner });
+    await resolveIamUsername(iamConnection(), { runner });
+
+    expect(calls).toHaveLength(1);
+  });
+
+  it('explains an expired SSO session rather than leaking the raw error', async () => {
+    const runner: AwsCommandRunner = async () => {
+      throw new Error('Error loading SSO Token: Token has expired and refresh failed');
+    };
+
+    await expect(resolveIamUsername(iamConnection(), { runner })).rejects.toThrow(
+      /aws sso login --profile example-int-db/
+    );
+  });
+});
+
+describe('resolveIamTarget', () => {
+  beforeEach(() => {
+    clearIamAuthCache();
+  });
+
+  it('assembles host, port, user, region and profile', async () => {
+    const target = await resolveIamTarget(iamConnection({ user: 'devuser' }), 5432, {
+      runner: stubRunner({}).runner,
+    });
+
+    expect(target).toEqual({
+      host: 'shared-int.cluster-x.us-east-1.rds.amazonaws.com',
+      port: 5432,
+      user: 'devuser',
+      region: 'us-east-1',
+      profile: 'example-int-db',
+    });
+  });
+
+  it('falls back to the region embedded in the RDS endpoint and the default port', async () => {
+    // No iamRegion property and no port: both must be inferred. This is the
+    // MySQL shape, whose JDBC URL carries no database either.
+    const conn = iamConnection({
+      user: 'devuser',
+      host: 'db.abc.us-gov-east-1.rds.amazonaws.com',
+      port: undefined,
+      properties: {
+        properties: { wrapperPlugins: 'iam', awsProfile: 'example-gov-db' },
+      } as unknown as Record<string, string>,
+    });
+
+    const target = await resolveIamTarget(conn, 3306, { runner: stubRunner({}).runner });
+    expect(target.region).toBe('us-gov-east-1');
+    expect(target.port).toBe(3306);
+    expect(target.profile).toBe('example-gov-db');
+  });
+
+  it('prefers the port recorded on the connection over the engine default', async () => {
+    const target = await resolveIamTarget(iamConnection({ user: 'devuser' }), 3306, {
+      runner: stubRunner({}).runner,
+    });
+    expect(target.port).toBe(5432);
+  });
+});
+
+describe('getIamAuthToken', () => {
+  beforeEach(() => {
+    clearIamAuthCache();
+  });
+
+  const target = {
+    host: 'db.cluster-x.us-east-1.rds.amazonaws.com',
+    port: 5432,
+    user: 'devuser',
+    region: 'us-east-1',
+    profile: 'example-int-db',
+  };
+
+  it('mints a token with the expected AWS CLI arguments', async () => {
+    const { runner, calls } = stubRunner({
+      'rds generate-db-auth-token': 'db.example.com:5432/?Action=connect&X-Amz-Signature=abc\n',
+    });
+
+    const token = await getIamAuthToken(target, { runner });
+
+    expect(token).toBe('db.example.com:5432/?Action=connect&X-Amz-Signature=abc');
+    expect(calls[0]).toEqual([
+      'rds',
+      'generate-db-auth-token',
+      '--hostname',
+      target.host,
+      '--port',
+      '5432',
+      '--username',
+      'devuser',
+      '--region',
+      'us-east-1',
+      '--profile',
+      'example-int-db',
+    ]);
+  });
+
+  it('reuses a cached token for the same target', async () => {
+    const { runner, calls } = stubRunner({ 'rds generate-db-auth-token': 'token-1' });
+
+    await getIamAuthToken(target, { runner });
+    await getIamAuthToken(target, { runner });
+
+    expect(calls).toHaveLength(1);
+  });
+
+  it('does not share tokens between different users or hosts', async () => {
+    const { runner, calls } = stubRunner({ 'rds generate-db-auth-token': 'token-1' });
+
+    await getIamAuthToken(target, { runner });
+    await getIamAuthToken({ ...target, user: 'someone_else' }, { runner });
+    await getIamAuthToken({ ...target, host: 'other.rds.amazonaws.com' }, { runner });
+
+    expect(calls).toHaveLength(3);
+  });
+
+  it('rejects an empty token instead of attempting a blank password', async () => {
+    const { runner } = stubRunner({ 'rds generate-db-auth-token': '   \n' });
+
+    await expect(getIamAuthToken(target, { runner })).rejects.toThrow(/empty RDS auth token/);
+  });
+});
+
+describe('resolveIamCredentials', () => {
+  beforeEach(() => {
+    clearIamAuthCache();
+  });
+
+  it('derives the username and mints a token in one step', async () => {
+    const { runner } = stubRunner({
+      'sts get-caller-identity': JSON.stringify({
+        Arn: 'arn:aws:sts::123:assumed-role/role/devuser@example.com',
+      }),
+      'rds generate-db-auth-token': 'signed-token',
+    });
+
+    const creds = await resolveIamCredentials(iamConnection(), 5432, { runner });
+
+    expect(creds).toEqual({ user: 'devuser', password: 'signed-token' });
+  });
+});

--- a/tests/ssl-config.test.ts
+++ b/tests/ssl-config.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { resolvePostgresSsl, resolveMysqlSsl } from '../src/auth/ssl.js';
+import { DatabaseConnection } from '../src/types.js';
+
+function connection(properties: Record<string, unknown>): DatabaseConnection {
+  return {
+    id: 'c1',
+    name: 'test',
+    driver: 'postgresql',
+    url: '',
+    properties: properties as unknown as Record<string, string>,
+  };
+}
+
+describe('resolvePostgresSsl', () => {
+  it('reads sslmode from nested driver properties', () => {
+    const ssl = resolvePostgresSsl(connection({ properties: { sslmode: 'require' } }));
+    expect(ssl).toEqual({ rejectUnauthorized: false });
+  });
+
+  it('reads sslmode from top-level properties', () => {
+    expect(resolvePostgresSsl(connection({ sslmode: 'require' }))).toEqual({
+      rejectUnauthorized: false,
+    });
+  });
+
+  it('verifies the server certificate for verify-full', () => {
+    expect(resolvePostgresSsl(connection({ sslmode: 'verify-full' }))).toEqual({
+      rejectUnauthorized: true,
+    });
+  });
+
+  it('honours an explicit disable', () => {
+    expect(resolvePostgresSsl(connection({ sslmode: 'disable' }))).toBe(false);
+  });
+
+  it('leaves the driver default alone when nothing is configured', () => {
+    expect(resolvePostgresSsl(connection({}))).toBeUndefined();
+  });
+
+  it('forces TLS for IAM auth, which RDS requires', () => {
+    expect(resolvePostgresSsl(connection({}), true)).toEqual({ rejectUnauthorized: false });
+  });
+
+  it('still respects an explicit disable under IAM auth', () => {
+    expect(resolvePostgresSsl(connection({ sslmode: 'disable' }), true)).toBe(false);
+  });
+
+  it('treats an enabled ssl handler as require', () => {
+    const ssl = resolvePostgresSsl(
+      connection({ handlers: { postgre_ssl: { enabled: true, properties: {} } } })
+    );
+    expect(ssl).toEqual({ rejectUnauthorized: false });
+  });
+});
+
+describe('resolveMysqlSsl', () => {
+  it('encrypts without verifying for REQUIRED, per MySQL ssl-mode semantics', () => {
+    // MySQL's REQUIRED does not authenticate the server certificate, and RDS
+    // certificates are not in the system trust store.
+    expect(resolveMysqlSsl(connection({ properties: { sslMode: 'REQUIRED' } }))).toEqual({
+      rejectUnauthorized: false,
+    });
+  });
+
+  it('verifies for VERIFY_IDENTITY', () => {
+    expect(resolveMysqlSsl(connection({ properties: { sslMode: 'VERIFY_IDENTITY' } }))).toEqual({
+      rejectUnauthorized: true,
+    });
+  });
+
+  it('honours an explicit disable', () => {
+    expect(resolveMysqlSsl(connection({ sslMode: 'DISABLED' }))).toBeUndefined();
+  });
+
+  it('leaves the driver default alone when nothing is configured', () => {
+    expect(resolveMysqlSsl(connection({}))).toBeUndefined();
+  });
+
+  it('forces TLS for IAM auth, which RDS requires', () => {
+    expect(resolveMysqlSsl(connection({}), true)).toEqual({ rejectUnauthorized: false });
+  });
+});


### PR DESCRIPTION
# Support custom drivers and AWS RDS IAM authentication

## The problem

OmniSQL dispatches to a native driver by substring-matching the workspace's driver id —
`postgres-jdbc` contains "postgres", `mysql8` contains "mysql". That holds for stock drivers, but
breaks for two increasingly common setups.

**1. Custom drivers have opaque ids.** A user-defined driver in a DBeaver-compatible client gets a
generated id — often a UUID, e.g. `35379A2C-3AE9-529E-B72B-244C753C055B`. It names no engine, so no
routing branch matches, and the connection falls through to the CLI fallback and fails. This affects
any hand-rolled or generated driver, including anything built on the
[AWS Advanced JDBC Wrapper](https://github.com/aws/aws-advanced-jdbc-wrapper), whose URLs also carry
a wrapper sub-protocol (`jdbc:aws-wrapper:postgresql://…`) that a naive URL parse misreads.

The connection record still identifies the engine, just not in the driver id: `provider` says
`postgresql`/`mysql`, and the JDBC URL names the engine behind any wrapper.

**2. IAM-authenticated connections have no password to read.** With RDS IAM auth the credential is a
signed token, minted per connection and valid 15 minutes. Nothing is stored in the workspace, so
OmniSQL had nothing to authenticate with, and such connections frequently omit the database username
too. TLS is mandatory — RDS rejects IAM tokens sent in cleartext.

## What changed

**Driver dialect resolution** (`src/utils.ts`, `src/config-parser.ts`). When a driver id names no
known engine, fall back to the connection's `provider`, then to the JDBC URL's sub-protocol, scanning
past wrapper protocols. Resolution happens once at parse time, so all existing routing — direct
queries, pools, transactions, query analysis, schema diff — keeps working unchanged. The raw id is
kept as `driverId` for display and error messages. Host, port and database are also backfilled from
the JDBC URL when the config omits them.

**AWS RDS IAM authentication** (`src/auth/iam-auth.ts`, new). Detected from AWS Advanced JDBC Wrapper
properties (`wrapperPlugins: "iam"`) or an `iam`-flavoured auth model. Tokens are minted with
`aws rds generate-db-auth-token`, delegating to the AWS CLI so SSO and role-chained profiles work as
the user already configured them — no new AWS SDK dependency. Tokens are cached 13 minutes under
their 15-minute lifetime, keyed per host/port/user/region/profile.

Long-lived pools refresh rather than expiring: `pg` receives an async `password` function and
`mysql2` an async `mysql_clear_password` plugin, each invoked per physical connection.

Where a connection records no username, it is derived from the caller's AWS identity — either the
assumed SSO session name, or, for role-chained profiles whose session name is SDK-generated
(`botocore-session-1785446405`), by stripping the profile prefix off the role name. Expired SSO
sessions produce an error naming the profile to re-authenticate.

**Shared TLS resolution** (`src/auth/ssl.ts`, new). The direct-query and pooled paths each had their
own copy, reading different property locations and disagreeing about what `require` meant. They now
share one implementation, which also fixes two bugs:

- MySQL TLS options were read only from top-level connection properties, ignoring the nested
  `properties` block the JSON workspace format writes. PostgreSQL already handled both.
- MySQL `REQUIRED` implied full certificate verification. Per MySQL's documented `ssl-mode`
  semantics, `REQUIRED` encrypts *without* validating the chain; only `VERIFY_CA` and
  `VERIFY_IDENTITY` verify it. The old behaviour cannot work against managed engines like RDS, whose
  CA is absent from the system trust store.

## Compatibility

Stock drivers are unaffected: an id that already names its engine is returned untouched, and the
IAM path only activates on connections that declare it.

Two observable changes worth review:

- `connection.driver` now holds the *resolved* dialect. `list_connections` additionally reports
  `driverId` and `provider`, but only when resolution was needed.
- The MySQL `REQUIRED` fix above is a deliberate behaviour change. Connections that set a MySQL TLS
  mode and relied on the previous stricter-than-documented verification would now encrypt without
  verifying. Setting `VERIFY_CA`/`VERIFY_IDENTITY` restores it.

No new runtime dependencies. Two new optional environment variables, `OMNISQL_AWS_CLI_PATH` and
`OMNISQL_IAM_TOKEN_TIMEOUT`, both documented in the README.

## Testing

52 new unit tests (94 total, all passing) covering dialect resolution, JDBC URL parsing, IAM
detection, region and username derivation, token caching, and TLS mode semantics. AWS calls run
through an injectable command runner, so the suite needs no AWS access.

Verified end to end through the MCP tool layer against live Amazon RDS: PostgreSQL 17.7 and MySQL
8.4.8, both via a custom AWS Advanced JDBC Wrapper driver with IAM auth and no stored credentials,
through both the direct-query and pooled-transaction paths.

Checked for regressions against a workspace of 20 connections, 18 of them stock password-based
Postgres and MySQL. Results were identical before and after the change.
